### PR TITLE
Support refresh_token in Ruby Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,23 @@ Usage
 First, you've to install the gem
 
 ```Ruby
-  gem install redbooth-ruby
+gem install redbooth-ruby
 ```
 
 and require it
 
 ```Ruby
-  require 'redbooth-ruby'
+require 'redbooth-ruby'
 ```
 
 and set up your app credentials
 
 
 ```Ruby
-  RedboothRuby.config do |configuration|
-    configuration[:consumer_key] = '_your_consumer_key_'
-    configuration[:consumer_secret] = '_your_consumer_secret_'
-  end
+RedboothRuby.config do |configuration|
+  configuration[:consumer_key] = '_your_consumer_key_'
+  configuration[:consumer_secret] = '_your_consumer_secret_'
+end
 ```
 
 in fact this last step is optional (yes! we support multiple applications) but if as most fo the humans you use only one redbooth app, this is the easyest way to go.
@@ -41,7 +41,7 @@ in fact this last step is optional (yes! we support multiple applications) but i
 Oauth
 =====
 
-*[Redbooth oauth2 API documentation](https://www.redbooth.com/developer/documentation#authentication)*
+*[Redbooth oauth2 API documentation](https://redbooth.com/api/authentication/)*
 
 using omniauth? :+1: good choice, just try this gem
 
@@ -58,28 +58,58 @@ Client
 Everything starts with the client, once you have the user credentials you should create a session and a client to start interaction with the API
 
 ```Ruby
-  session = RedboothRuby::Session.new(
-    token: '_your_user_token_'
-  )
-  client = RedboothRuby::Client.new(session)
+session = RedboothRuby::Session.new(
+  token: '_your_user_token_'
+)
+client = RedboothRuby::Client.new(session)
 ```
 
 Now you can perform any user api call inside the clien wrapper
 
 ```Ruby
-  client.me(:show)
+client.me(:show)
 ```
 
 If you have multiple applications or you just want to ve explicit use the application credentials inside the session creation
 
 ```Ruby
-  session = RedboothRuby::Session.new(
-    token: '_your_user_token_',
-    consumer_key: '_your_app_key_',
-    consumer_secret: '_your_app_secret'
-  )
-  client = RedboothRuby::Client.new(session)
+session = RedboothRuby::Session.new(
+  token: '_your_user_token_',
+  consumer_key: '_your_app_key_',
+  consumer_secret: '_your_app_secret'
+)
+client = RedboothRuby::Client.new(session)
 ```
+
+Refresh Token
+------
+
+By default, your access token will expires in 7200 seconds (2 hours). If you want to automatically get a new one, just need to provide the ```refresh_token``` param
+
+```Ruby
+session = RedboothRuby::Session.new(
+  token: '_your_user_token_',
+  refresh_token: '_your_user_refresh_token_',
+  auto_refresh_token: true
+)
+```
+
+You can also provide a callback to get the new access token:
+
+```Ruby
+session = RedboothRuby::Session.new(
+  token: '_your_user_token_',
+  refresh_token: '_your_user_refresh_token_',
+  auto_refresh_token: true,
+  on_token_refresh: Proc.new do |old_access_token, new_access_token|
+    auth = Authentication.where(access_token: old_access_token.token).first
+    auth.access_token = new_access_token.token
+    auth.refresh_token = new_access_token.refresh_token
+    auth.save
+  end
+)
+```
+
 
 Async Endpoints
 ======
@@ -156,14 +186,14 @@ Users
 List users in your network
 
 ```Ruby
-  users_collection = client.user(:index)
-  users = users_collection.all
+users_collection = client.user(:index)
+users = users_collection.all
 ```
 
 Fetch a specific user
 
 ```Ruby
-  user = client.user(:show, id: 123)
+user = client.user(:show, id: 123)
 ```
 
 TaskLists
@@ -172,34 +202,34 @@ TaskLists
 Lists task lists in your visibility scope
 
 ```Ruby
-  tasklists_collection = client.task_list(:index)
-  tasklists = tasklists_collection.all
+tasklists_collection = client.task_list(:index)
+tasklists = tasklists_collection.all
 ```
 
 You can also filter by multiple params (see docs [here](https://redbooth.com/api/api-docs/#page:tasklists,header:tasklists-tasklist-list) )
 
 ```Ruby
-  filtered_tasklists = client.task_list(:index, order: 'id-DESC',
-                                                per_page: 50,
-                                                project_id: 123)
+filtered_tasklists = client.task_list(:index, order: 'id-DESC',
+                                              per_page: 50,
+                                              project_id: 123)
 ```
 
 Fetch a specific tasklist
 
 ```Ruby
-  tasklist = client.task_list(:show, id: 123)
+tasklist = client.task_list(:show, id: 123)
 ```
 
 Update a specific tasklist
 
 ```Ruby
-  tasklist = client.task_list(:update, id: 123, name: 'new name')
+tasklist = client.task_list(:update, id: 123, name: 'new name')
 ```
 
 Delete a specific tasklist
 
 ```Ruby
-  client.task_list(:delete, id: 123)
+client.task_list(:delete, id: 123)
 ```
 
 Tasks
@@ -208,34 +238,34 @@ Tasks
 Lists tasks in your visibility scope
 
 ```Ruby
-  tasks_collection = client.task(:index)
-  tasks = tasks_collection.all
+tasks_collection = client.task(:index)
+tasks = tasks_collection.all
 ```
 
 You can also filter by multiple params (see docs [here](https://redbooth.com/api/api-docs/#page:tasks,header:tasks-task-list) )
 
 ```Ruby
-  filtered_tasks = client.task(:index, order: 'id-DESC',
-                                        per_page: 50,
-                                        project_id: 123)
+filtered_tasks = client.task(:index, order: 'id-DESC',
+                                      per_page: 50,
+                                      project_id: 123)
 ```
 
 Fetch a specific task
 
 ```Ruby
-  task = client.task(:show, id: 123)
+task = client.task(:show, id: 123)
 ```
 
 Update a specific task
 
 ```Ruby
-  task = client.task(:update, id: 123, name: 'new name')
+task = client.task(:update, id: 123, name: 'new name')
 ```
 
 Delete a specific task
 
 ```Ruby
-  client.task(:delete, id: 123)
+client.task(:delete, id: 123)
 ```
 
 Organizations
@@ -244,39 +274,39 @@ Organizations
 Lists organizations in your visibility scope
 
 ```Ruby
-  organization_collection = client.organization(:index)
-  organizations = organization_collection.all
+organization_collection = client.organization(:index)
+organizations = organization_collection.all
 ```
 
 You can also filter by multiple params (see docs [here](https://redbooth.com/api/api-docs/#page:organizations,header:organizations-organization-list) )
 
 ```Ruby
-  filtered_organizations = client.organization(:index, order: 'id-DESC',
-                                                       per_page: 50)
+filtered_organizations = client.organization(:index, order: 'id-DESC',
+                                                     per_page: 50)
 ```
 
 Fetch a specific organization
 
 ```Ruby
-  organization = client.organization(:show, id: 123)
+organization = client.organization(:show, id: 123)
 ```
 
 Create a organization
 
 ```Ruby
-  organization = client.organization(:create, name: 'New Organization')
+organization = client.organization(:create, name: 'New Organization')
 ```
 
 Update a specific organization
 
 ```Ruby
-  organization = client.organization(:update, id: 123, name: 'new name')
+organization = client.organization(:update, id: 123, name: 'new name')
 ```
 
 Delete a specific organization
 
 ```Ruby
-  client.organization(:delete, id: 123)
+client.organization(:delete, id: 123)
 ```
 
 Projects
@@ -285,39 +315,38 @@ Projects
 Lists projects in your visibility scope
 
 ```Ruby
-  project_collection = client.project(:index)
-  projects = project_collection.all
+project_collection = client.project(:index)
+projects = project_collection.all
 ```
 
 You can also filter by multiple params (see docs [here](https://redbooth.com/api/api-docs/#page:projects,header:projects-project-list) )
 
 ```Ruby
-  filtered_projects = client.project(:index, order: 'id-DESC',
-                                                       per_page: 50)
+filtered_projects = client.project(:index, order: 'id-DESC', per_page: 50)
 ```
 
 Fetch a specific project
 
 ```Ruby
-  project = client.project(:show, id: 123)
+project = client.project(:show, id: 123)
 ```
 
 Create a project
 
 ```Ruby
-  project = client.project(:create, name: 'New Project')
+project = client.project(:create, name: 'New Project')
 ```
 
 Update a specific project
 
 ```Ruby
-  project = client.project(:update, id: 123, name: 'new name')
+project = client.project(:update, id: 123, name: 'new name')
 ```
 
 Delete a specific project
 
 ```Ruby
-  client.project(:delete, id: 123)
+client.project(:delete, id: 123)
 ```
 
 People
@@ -337,39 +366,38 @@ information
 Lists People in your visibility scope
 
 ```Ruby
-  people_collection = client.person(:index)
-  people = people_collection.all
+people_collection = client.person(:index)
+people = people_collection.all
 ```
 
 You can also filter by multiple params (see docs [here](https://redbooth.com/api/api-docs/#page:people,header:people-people-list) )
 
 ```Ruby
-  filtered_people = client.person(:index, order: 'id-DESC',
-                                          per_page: 50)
+filtered_people = client.person(:index, order: 'id-DESC', per_page: 50)
 ```
 
 Fetch a specific person
 
 ```Ruby
-  people = client.person(:show, id: 123)
+people = client.person(:show, id: 123)
 ```
 
 Create a person
 
 ```Ruby
-  person = client.person(:create, project_id: 123, user_id: 123, role: 'participant')
+person = client.person(:create, project_id: 123, user_id: 123, role: 'participant')
 ```
 
 Update a specific person
 
 ```Ruby
-  person = client.person(:update, id: 123, role: 'admin')
+person = client.person(:update, id: 123, role: 'admin')
 ```
 
 Delete a specific person
 
 ```Ruby
-  client.person(:delete, id: 123)
+client.person(:delete, id: 123)
 ```
 
 Memberships
@@ -388,39 +416,39 @@ Memberships is the redbooth relation between organization and users containing t
 Lists Memberships in your visibility scope
 
 ```Ruby
-  membership_collection = client.membership(:index)
-  memberships = membership_collection.all
+membership_collection = client.membership(:index)
+memberships = membership_collection.all
 ```
 
 You can also filter by multiple params (see docs [here](https://redbooth.com/api/api-docs/#page:memberships,header:memberships-memberships-list) )
 
 ```Ruby
-  filtered_memberships = client.membership(:index, order: 'id-DESC',
-                                                   per_page: 50)
+filtered_memberships = client.membership(:index, order: 'id-DESC', per_page: 50)
 ```
 
 Fetch a specific membership
 
 ```Ruby
-  memberships = client.membership(:show, id: 123)
+memberships = client.membership(:show, id: 123)
 ```
 
 Create a membership
 
 ```Ruby
-  membership = client.membership(:create, organization_id: 123, user_id: 123, role: 'participant')
+membership = client.membership(:create, organization_id: 123, user_id: 123,
+  role: 'participant')
 ```
 
 Update a specific membership
 
 ```Ruby
-  membership = client.membership(:update, id: 123, role: 'admin')
+membership = client.membership(:update, id: 123, role: 'admin')
 ```
 
 Delete a specific membership
 
 ```Ruby
-  client.membership(:delete, id: 123)
+client.membership(:delete, id: 123)
 ```
 
 Conversations
@@ -429,34 +457,34 @@ Conversations
 Lists conversations in your visibility scope
 
 ```Ruby
-  conversation_collection = client.conversation(:index)
-  conversations = conversation_collection.all
+conversation_collection = client.conversation(:index)
+conversations = conversation_collection.all
 ```
 
 You can also filter by multiple params (see docs [here](https://redbooth.com/api/api-docs/#page:conversations,header:conversations-conversations-list) )
 
 ```Ruby
-  filtered_conversations = client.conversation(:index, order: 'id-DESC',
-                                                       per_page: 50,
-                                                       project_id: 123)
+filtered_conversations = client.conversation(:index, order: 'id-DESC',
+                                                     per_page: 50,
+                                                     project_id: 123)
 ```
 
 Fetch a specific conversation
 
 ```Ruby
-  conversation = client.conversation(:show, id: 123)
+conversation = client.conversation(:show, id: 123)
 ```
 
 Update a specific conversation
 
 ```Ruby
-  conversation = client.conversation(:update, id: 123, name: 'new name')
+conversation = client.conversation(:update, id: 123, name: 'new name')
 ```
 
 Delete a specific conversation
 
 ```Ruby
-  client.conversation(:delete, id: 123)
+client.conversation(:delete, id: 123)
 ```
 
 Comments
@@ -470,36 +498,36 @@ To consume the comments endpoint you allways need to provide a `target_type` and
 Lists comments in your visibility scope
 
 ```Ruby
-  comment_collection = client.comment(:index, target_type: 'task', target_id: 123)
-  comments = comment_collection.all
+comment_collection = client.comment(:index, target_type: 'task', target_id: 123)
+comments = comment_collection.all
 ```
 
 You can also filter by multiple params (see docs [here](https://redbooth.com/api/api-docs/#page:comments,header:comments-commnets-list) )
 
 ```Ruby
-  filtered_comments = client.comment(:index, order: 'id-DESC',
-                                             per_page: 50,
-                                             project_id: 123,
-                                             target_type: 'task',
-                                             target_id: 123)
+filtered_comments = client.comment(:index, order: 'id-DESC',
+                                           per_page: 50,
+                                           project_id: 123,
+                                           target_type: 'task',
+                                           target_id: 123)
 ```
 
 Fetch a specific comment
 
 ```Ruby
-  comment = client.comment(:show, id: 123)
+comment = client.comment(:show, id: 123)
 ```
 
 Update a specific comment
 
 ```Ruby
-  comment = client.comment(:update, id: 123, body: 'new body content')
+comment = client.comment(:update, id: 123, body: 'new body content')
 ```
 
 Delete a specific comment
 
 ```Ruby
-  client.comment(:delete, id: 123)
+client.comment(:delete, id: 123)
 ```
 
 Notes
@@ -508,34 +536,34 @@ Notes
 Lists notes in your visibility scope
 
 ```Ruby
-  notes_collection = client.note(:index)
-  notes = notes_collection.all
+notes_collection = client.note(:index)
+notes = notes_collection.all
 ```
 
 You can also filter by multiple params (see docs [here](https://redbooth.com/api/api-docs/#page:notes,header:notes-notes-list) )
 
 ```Ruby
-  filtered_notes = client.note(:index, order: 'id-DESC',
-                                       per_page: 50,
-                                       project_id: 123)
+filtered_notes = client.note(:index, order: 'id-DESC',
+                                     per_page: 50,
+                                     project_id: 123)
 ```
 
 Fetch a specific note
 
 ```Ruby
-  note = client.note(:show, id: 123)
+note = client.note(:show, id: 123)
 ```
 
 Update a specific note
 
 ```Ruby
-  note = client.note(:update, id: 123, name: 'new name')
+note = client.note(:update, id: 123, name: 'new name')
 ```
 
 Delete a specific note
 
 ```Ruby
-  client.note(:delete, id: 123)
+client.note(:delete, id: 123)
 ```
 
 Subtasks
@@ -546,40 +574,40 @@ Subtasks are little sentences under a task that could de resolved or not.
 Lists subtasks in your visibility scope. Needs a task_id
 
 ```Ruby
-  subtask_collection = client.subtask(:index, task_id: 123)
-  subtasks = subtask_collection.all
+subtask_collection = client.subtask(:index, task_id: 123)
+subtasks = subtask_collection.all
 ```
 
 You can also filter by multiple params (see docs [here](https://redbooth.com/api/api-docs/#page:subtasks,header:subtasks-subtasks-list) )
 
 ```Ruby
-  filtered_subtasks = client.subtask(:index, task_id: 123,
-                                             order: 'id-DESC',
-                                             per_page: 50)
+filtered_subtasks = client.subtask(:index, task_id: 123,
+                                           order: 'id-DESC',
+                                           per_page: 50)
 ```
 
 Fetch a specific subtask
 
 ```Ruby
-  subtask = client.subtask(:show, id: 123)
+subtask = client.subtask(:show, id: 123)
 ```
 
 Create a new subtask
 
 ```Ruby
-  subtask = client.subtask(:create, task_id: 123, name: 'new name')
+subtask = client.subtask(:create, task_id: 123, name: 'new name')
 ```
 
 Update a specific subtask
 
 ```Ruby
-  subtask = client.subtask(:update, id: 123, name: 'new name')
+subtask = client.subtask(:update, id: 123, name: 'new name')
 ```
 
 Delete a specific subtask
 
 ```Ruby
-  client.subtask(:delete, id: 123)
+client.subtask(:delete, id: 123)
 ```
 
 Files
@@ -590,48 +618,48 @@ Files in redbooth could be uploaded or choosen form other service providers (Cop
 Lists files in your visibility scope.
 
 ```Ruby
-  files_colilection = client.file(:index)
-  files = files_collection.all
+files_colilection = client.file(:index)
+files = files_collection.all
 ```
 
 You can also filter by multiple params (see docs [here](https://redbooth.com/api/api-docs/#page:subtasks,header:subtasks-subtasks-list) )
 
 ```Ruby
-  filtered_files_collection = client.file(:index, backend: 'redbooth',
-                                                  project_id: 123,
-                                                  order: 'id-DESC',
-                                                  per_page: 25)
+filtered_files_collection = client.file(:index, backend: 'redbooth',
+                                                project_id: 123,
+                                                order: 'id-DESC',
+                                                per_page: 25)
 ```
 
 Update a specific file
 
 ```Ruby
-  file = client.file(:update, id: 123, name: 'new_name.doc')
+file = client.file(:update, id: 123, name: 'new_name.doc')
 ```
 
 Create a new file
 
 ```Ruby
-  file = File.open('path/to/the/file')
-  new_file = client.file(:create, project_id: 123,
-                                  parent_id: nil,
-                                  backend: 'redbooth',
-                                  is_dir: false,
-                                  asset: file )
+file = File.open('path/to/the/file')
+new_file = client.file(:create, project_id: 123,
+                                parent_id: nil,
+                                backend: 'redbooth',
+                                is_dir: false,
+                                asset: file )
 ```
 
 Delete a specific subtask
 
 ```Ruby
-  client.file(:delete, id: 123)
+client.file(:delete, id: 123)
 ```
 
 Download a file
 
 ```Ruby
-  file # RedBoothRuby::File
+file # RedBoothRuby::File
 
-  open('/path/to/your_new_file.txt', 'w') { |f| f.puts file.download }
+open('/path/to/your_new_file.txt', 'w') { |f| f.puts file.download }
 ```
 
 Search
@@ -649,7 +677,7 @@ You can search throught any redbooth entity by using the search method. There is
 Search for redbooth objects in your visibility scope
 
 ```Ruby
-  entities = client.search(query: 'task+nothing*')
+entities = client.search(query: 'task+nothing*')
 ```
 
 Metadata
@@ -663,25 +691,25 @@ This is really helpful when doing API syncs or tiny implementations in top of th
 Fetch object metadata
 
 ```Ruby
-  task.metadata
+task.metadata
 ```
 
 Update object metadata by adding new keys or overwriding the exisiting ones but not touching the others if there is any one.
 
 ```Ruby
-  task.metadata_merge("new_key" => "new value")
+task.metadata_merge("new_key" => "new value")
 ```
 
 Restore user metadata by overwiritng the existing ones.
 
 ```Ruby
-  task.metadata = {"key" => "value"}
+task.metadata = {"key" => "value"}
 ```
 
 Search for a certain metadata key value
 
 ```Ruby
-  metadata_collection = client.metadata(key: 'key', value: 'value', target_type: 'Task')
+metadata_collection = client.metadata(key: 'key', value: 'value', target_type: 'Task')
 ```
 
 License

--- a/lib/redbooth-ruby.rb
+++ b/lib/redbooth-ruby.rb
@@ -49,14 +49,15 @@ module RedboothRuby
   end
 
   module ClientOperations
+    autoload :Perform,    'redbooth-ruby/client_operations/perform'
     autoload :Search,     'redbooth-ruby/client_operations/search'
     autoload :Metadata,   'redbooth-ruby/client_operations/metadata'
   end
 
   class RedboothError < StandardError; end
   class AuthenticationError < RedboothError; end
-  class OauhtTokenExpired < AuthenticationError; end
-  class OauhtTokenRevoked < AuthenticationError; end
+  class OauthTokenExpired < AuthenticationError; end
+  class OauthTokenRevoked < AuthenticationError; end
   class NotFound            < RedboothError; end
   class APIError            < RedboothError; end
   class ObjectNotFound      < APIError; end

--- a/lib/redbooth-ruby/client.rb
+++ b/lib/redbooth-ruby/client.rb
@@ -28,7 +28,7 @@ module RedboothRuby
     #
     # @param [String||Symbol] action name of the action to execute over
     # @param [Hash] options for the execution
-    # @returns the execution return or nil
+    # @return the execution return or nil
     #
     # @example
     #   session = RedboothRuby::Session.new(api_key: '_your_api_key_', auth_token: '_aut_token_for_the_user')
@@ -51,43 +51,9 @@ module RedboothRuby
     # @param [String||Symbol] resource_name name of the resource to execute over
     # @param [String||Symbol] action name of the action to execute over
     # @param [Hash] options for the execution
-    # @returns the execution return or nil
+    # @return the execution return or nil
     def perform!(resource_name, action, options = {})
-      fail RedboothRuby::AuthenticationError unless session
-      resource(resource_name).send(action, options_with_session(options))
-    rescue Processing => processing
-      delay = processing.response.data["retry_after"] || 10
-      retry_in(delay, resource_name, action, options)
+      ClientOperations::Perform.new(resource_name, action, session, options).perform!
     end
-
-    # Retryes the request in the given time
-    # either calls the given proc options[:retry]
-    # or executes it in this thread
-    #
-    def retry_in(delay, *args)
-      if options[:retry]
-        options[:retry].call(delay)
-      else
-        sleep(delay)
-        perform!(*args)
-      end
-    end
-
-    # Merge the given options with the session for use the api
-    #
-    # @param [Hash] options options to merge with session
-    # @return [Hash]
-    def options_with_session(options={})
-      options.merge(session: @session)
-    end
-
-    # Get the api resource model class by his name
-    #
-    # @param [String||Symbol] name name of the resource
-    # @return [Copy::Base] resource to use the api
-    def resource(name)
-      eval('RedboothRuby::' + camelize(name)) rescue nil
-    end
-
   end
 end

--- a/lib/redbooth-ruby/client_operations/perform.rb
+++ b/lib/redbooth-ruby/client_operations/perform.rb
@@ -1,0 +1,93 @@
+module RedboothRuby
+  module ClientOperations
+    class Perform
+      include RedboothRuby::Helpers
+      attr_accessor :resource_name, :action, :session, :options
+      attr_accessor :tries, :processing_error, :oauth_token_expired_error
+
+      def initialize(resource_name, action, session, options = {})
+        @resource_name = resource_name
+        @action = action
+        @session = session
+        @options = options
+        @tries = 0
+      end
+
+      # Performs the resource action
+      #
+      # @return the execution return or nil
+      def perform!
+        @tries += 1
+        fail RedboothRuby::AuthenticationError unless session
+        resource(resource_name).send(action, options_with_session(options))
+      rescue Processing => processing_error
+        @processing_error = processing_error
+        perform_processing!
+      rescue OauthTokenExpired => oauth_token_expired_error
+        @oauth_token_expired_error = oauth_token_expired_error
+        perform_oauth_token_expired!
+      end
+
+      # Delays the execution of the enqueued processing
+      #
+      # @return the execution return or nil
+      def perform_processing!
+        delay = if processing_error && processing_error.response
+          processing_error.response.data['retry_after'].to_i
+        else
+          10
+        end
+        retry_in(delay)
+      end
+
+      # Perform refresh on the session access token
+      #
+      # @return the execution return or raise OauthTokenExpired
+      def perform_oauth_token_expired!
+        if tries == 1 && refresh_session_access_token!
+          perform!
+        else
+          raise oauth_token_expired_error
+        end
+      end
+
+      private
+
+      # Retries the request in the given time either calls the given
+      # proc options[:retry] or executes it in this thread
+      #
+      def retry_in(delay)
+        if options[:retry]
+          options[:retry].call(delay)
+        else
+          sleep(delay)
+          perform!
+        end
+      end
+
+      # Merge the given options with the session for use the api
+      #
+      # @param [Hash] options options to merge with session
+      # @return [Hash]
+      def options_with_session(options={})
+        options.merge(session: @session)
+      end
+
+      # Get the api resource model class by his name
+      #
+      # @param [String||Symbol] name name of the resource
+      # @return [Copy::Base] resource to use the api
+      def resource(name)
+        Object.const_get("RedboothRuby::#{camelize(name)}") rescue nil
+      end
+
+      # Refresh the session access token if auto_refresh_token is enabled
+      #
+      # @return [Boolean]
+      def refresh_session_access_token!
+        session.auto_refresh_token && session.refresh_access_token!
+      end
+
+    end
+  end
+end

--- a/lib/redbooth-ruby/helpers.rb
+++ b/lib/redbooth-ruby/helpers.rb
@@ -6,20 +6,20 @@ module RedboothRuby
     #   capitalize the first letter
     #   capitalize the first letter after _'s, removing the _'s
     # Example: camelize(:task_list)   # => TaskList
-    # Example: camelize("task_list")  # => TaskList
-    # 
-    # @param  [Symbol|String] name to convert  
-    # @return [String] string of the class name  
+    # Example: camelize('task_list')  # => TaskList
+    #
+    # @param  [Symbol|String] name to convert
+    # @return [String] string of the class name
     def camelize(name)
       name.to_s.gsub(/\/(.?)/) { "::#{$1.upcase}" }.gsub(/(?:^|_)(.)/) { $1.upcase }
     end
 
     # Transform a class name into a resource name.
     # Downcase all the letters, inserting an underscore _ before capitals
-    # Example: underscore("TaskList")   # => task_list
-    # 
-    # @param  [String] camel_case_word to convert  
-    # @return [String] string of the resource name  
+    # Example: underscore('TaskList')   # => task_list
+    #
+    # @param  [String] camel_case_word to convert
+    # @return [String] string of the resource name
     def underscore(camel_case_word)
       camel_case_word.gsub(/::/, '/').
         gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').

--- a/lib/redbooth-ruby/operations/base.rb
+++ b/lib/redbooth-ruby/operations/base.rb
@@ -21,7 +21,7 @@ module RedboothRuby
         #
         def api_member_url(id = nil, method = nil)
           url = api_resource_name(method)
-          url += "/#{id}" if id
+          url += "/#{ id }" if id
           url
         end
 
@@ -36,7 +36,7 @@ module RedboothRuby
         # overwrite this in the model if the api is not well named
         #
         def api_resource_name(method = nil)
-          "#{underscore(name.split('::').last)}s"
+          "#{ underscore(name.split('::').last) }s"
         end
       end
 

--- a/lib/redbooth-ruby/request/connection.rb
+++ b/lib/redbooth-ruby/request/connection.rb
@@ -23,8 +23,8 @@ module RedboothRuby
           access_token.send(*request_data)
         end
       end
-      
-      # Downloads the desired file following redirects to 
+
+      # Downloads the desired file following redirects to
       # amazon s3 without authentication headers
       #
       def download_file_with_redirect
@@ -136,10 +136,10 @@ module RedboothRuby
 
       # Returns the api url for this request or default
       def api_url
-        url =  "#{api_url_method}#{api_url_domain}"
-        url += "#{RedboothRuby.configuration[:api_base]}"
-        url += "#{api_url_path}"
-        url += "#{api_url_version}"
+        url =  "#{ api_url_method}#{api_url_domain }"
+        url += "#{ RedboothRuby.configuration[:api_base] }"
+        url += "#{ api_url_path }"
+        url += "#{ api_url_version }"
         if @info
           url += @info.url
           if use_url_params? && !body_hash.empty?
@@ -159,7 +159,7 @@ module RedboothRuby
 
       def api_url_domain
         return '' unless domain
-        "#{domain}."
+        "#{ domain }."
       end
 
       def api_url_path

--- a/lib/redbooth-ruby/request/helpers.rb
+++ b/lib/redbooth-ruby/request/helpers.rb
@@ -23,7 +23,7 @@ module RedboothRuby
             result[name.to_s] = normalize_params(value)
           when Array
             value.each_with_index do |item_value, index|
-              result["#{name.to_s}[#{index}]"] = item_value.to_s
+              result["#{ name.to_s }[#{ index }]"] = item_value.to_s
             end
           else
             result[name.to_s] = value.to_s

--- a/lib/redbooth-ruby/request/info.rb
+++ b/lib/redbooth-ruby/request/info.rb
@@ -25,7 +25,7 @@ module RedboothRuby
       def path_with_params(path, params)
         unless params.empty?
           encoded_params = URI.encode_www_form(params)
-          [path, encoded_params].join("?")
+          [path, encoded_params].join('?')
         else
           path
         end

--- a/lib/redbooth-ruby/request/validator.rb
+++ b/lib/redbooth-ruby/request/validator.rb
@@ -47,9 +47,9 @@ module RedboothRuby
       def verify_authentication_header
         case raw_response.headers['WWW-Authenticate']
         when /error\=\"invalid_token\".*expired/
-          fail OauhtTokenExpired
+          fail OauthTokenExpired
         when /error\=\"invalid_token\".*revoked/
-          fail OauhtTokenRevoked
+          fail OauthTokenRevoked
         end
       end
 

--- a/lib/redbooth-ruby/session.rb
+++ b/lib/redbooth-ruby/session.rb
@@ -3,18 +3,23 @@ require 'oauth2'
 module RedboothRuby
   class Session
 
-    attr_accessor :token, :refresh_token, :access_token
+    attr_accessor :token, :access_token
+    attr_accessor :refresh_token, :expires_in, :auto_refresh_token, :on_token_refresh
     attr_accessor :consumer_key, :consumer_secret
     attr_accessor :oauth_verifier, :oauth_token
 
     OAUTH_URLS =  {
-        :site => 'https://redbooth.com/api/3',
-        :authorize_url => 'https://redbooth.com/oauth2/authorize',
-        :token_url => 'https://redbooth.com/oauth2/token'
+      site: 'https://redbooth.com/api/3',
+      authorize_url: 'https://redbooth.com/oauth2/authorize',
+      token_url: 'https://redbooth.com/oauth2/token'
     }
 
     def initialize(opts = {})
       @token = opts[:token]
+      @refresh_token = opts[:refresh_token]
+      @expires_in = opts[:expires_in]
+      @auto_refresh_token = opts[:auto_refresh_token] || true
+      @on_token_refresh = opts[:on_token_refresh]
       @consumer_key = opts[:consumer_key] || RedboothRuby.configuration[:consumer_key]
       @consumer_secret = opts[:consumer_secret] || RedboothRuby.configuration[:consumer_secret]
       @oauth_verifier = opts[:oauth_verifier]
@@ -31,16 +36,34 @@ module RedboothRuby
     end
 
     def get_access_token_url
-      url = OAUTH_URLS[:request_token_url]
-      url += "?oauth_verifier=#{oauth_verifier}" if oauth_verifier
-      url += "&oauth_token=#{oauth_token}" if oauth_token
+      uri = URI.parse(OAUTH_URLS[:token_url])
+      params = URI.decode_www_form(uri.query.to_s)
+      params << ['oauth_verifier', oauth_verifier] if oauth_verifier
+      params << ['oauth_token', oauth_token] if oauth_token
+      uri.query = URI.encode_www_form(params) if params.size > 0
+      uri.to_s
     end
 
     def access_token
-      @access_token ||= OAuth2::AccessToken.new(client, token)
+      @access_token ||= OAuth2::AccessToken.new(client, token,
+       refresh_token: refresh_token, expires_in: expires_in)
     end
 
+    def refresh_access_token!
+      new_access_token = access_token.refresh!
+      if new_access_token
+        on_token_refresh.call(access_token, new_access_token) if on_token_refresh.is_a?(Proc)
+        @access_token = new_access_token
+      end
+      new_access_token
+    end
+
+    def on_token_refresh(&block)
+      if block_given?
+        @on_token_refresh = block
+      else
+        @on_token_refresh
+      end
+    end
   end
 end
-
-

--- a/lib/redbooth-ruby/version.rb
+++ b/lib/redbooth-ruby/version.rb
@@ -1,3 +1,3 @@
 module RedboothRuby
-  VERSION = '0.0.6'
+  VERSION = '0.1.0'
 end

--- a/spec/cassettes/RedboothRuby_Organization/_delete/makes_a_new_DELETE_request_using_the_correct_API_endpoint_to_delete_a_specific_organization.yml
+++ b/spec/cassettes/RedboothRuby_Organization/_delete/makes_a_new_DELETE_request_using_the_correct_API_endpoint_to_delete_a_specific_organization.yml
@@ -42,7 +42,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"type":"Organization","created_at":1415197273,"updated_at":1415197273,"id":12,"name":"new
         Organization","permalink":"new-organization-fx0qk","domain":null,"settings":{"allow_comment_deletion":true},"omit_email_processing":false,"product":"50-seats-trial","product_name":"trial","feature_level":"freeu","subscription_id":12,"seats":50,"remaining_users":49,"available_users":50,"used_users":1,"remaining_projects":999998,"available_projects":999999,"used_projects":1,"metadata":{},"square_logo_url":"/images/logos/square/missing.png","top_logo_url":"/images/logos/top/missing.png","has_logo":false,"is_pro":true,"description":null}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Nov 2014 14:21:19 GMT
 - request:
     method: delete
@@ -80,8 +80,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":"/api/3/organizations/12action=destroy\u0026controller=api_v3%2Forganizations\u0026id=12","retry_after":null}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":"/api/3/organizations/12action=destroy\u0026controller=api_v3%2Forganizations\u0026id=12","retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 14:21:49 GMT
 - request:
     method: delete
@@ -118,6 +118,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Nov 2014 14:36:02 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/RedboothRuby_Project/_delete/makes_a_new_DELETE_request_using_the_correct_API_endpoint_to_delete_a_specific_project.yml
+++ b/spec/cassettes/RedboothRuby_Project/_delete/makes_a_new_DELETE_request_using_the_correct_API_endpoint_to_delete_a_specific_project.yml
@@ -42,7 +42,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"type":"Project","created_at":1415206100,"updated_at":1415206100,"id":22,"permalink":"new-project","organization_id":1,"archived":false,"name":"new
         Project","description":null,"start_date":null,"end_date":null,"tracks_time":false,"public":null,"publish_pages":false,"settings":{},"deleted":false}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:21 GMT
 - request:
     method: delete
@@ -80,8 +80,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":"/api/3/projects/22action=destroy\u0026controller=api_v3%2Fprojects\u0026id=22","retry_after":null}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":"/api/3/projects/22action=destroy\u0026controller=api_v3%2Fprojects\u0026id=22","retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:21 GMT
 - request:
     method: delete
@@ -121,8 +121,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:21 GMT
 - request:
     method: delete
@@ -162,8 +162,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:21 GMT
 - request:
     method: delete
@@ -203,8 +203,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:21 GMT
 - request:
     method: delete
@@ -244,8 +244,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:21 GMT
 - request:
     method: delete
@@ -285,8 +285,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:21 GMT
 - request:
     method: delete
@@ -326,8 +326,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:21 GMT
 - request:
     method: delete
@@ -367,8 +367,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:21 GMT
 - request:
     method: delete
@@ -408,8 +408,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:21 GMT
 - request:
     method: delete
@@ -449,8 +449,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:22 GMT
 - request:
     method: delete
@@ -490,8 +490,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:22 GMT
 - request:
     method: delete
@@ -531,8 +531,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:22 GMT
 - request:
     method: delete
@@ -572,8 +572,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:22 GMT
 - request:
     method: delete
@@ -613,8 +613,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:22 GMT
 - request:
     method: delete
@@ -654,8 +654,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:22 GMT
 - request:
     method: delete
@@ -695,8 +695,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:22 GMT
 - request:
     method: delete
@@ -736,8 +736,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:22 GMT
 - request:
     method: delete
@@ -777,8 +777,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:22 GMT
 - request:
     method: delete
@@ -818,8 +818,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:22 GMT
 - request:
     method: delete
@@ -859,8 +859,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:23 GMT
 - request:
     method: delete
@@ -900,8 +900,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:23 GMT
 - request:
     method: delete
@@ -941,8 +941,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:23 GMT
 - request:
     method: delete
@@ -982,8 +982,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:23 GMT
 - request:
     method: delete
@@ -1023,8 +1023,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:23 GMT
 - request:
     method: delete
@@ -1064,8 +1064,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:23 GMT
 - request:
     method: delete
@@ -1105,8 +1105,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:23 GMT
 - request:
     method: delete
@@ -1146,8 +1146,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:23 GMT
 - request:
     method: delete
@@ -1187,8 +1187,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:24 GMT
 - request:
     method: delete
@@ -1228,8 +1228,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:24 GMT
 - request:
     method: delete
@@ -1269,8 +1269,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:24 GMT
 - request:
     method: delete
@@ -1310,8 +1310,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:24 GMT
 - request:
     method: delete
@@ -1351,8 +1351,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:24 GMT
 - request:
     method: delete
@@ -1392,8 +1392,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:24 GMT
 - request:
     method: delete
@@ -1433,8 +1433,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:24 GMT
 - request:
     method: delete
@@ -1474,8 +1474,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:24 GMT
 - request:
     method: delete
@@ -1515,8 +1515,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:24 GMT
 - request:
     method: delete
@@ -1556,8 +1556,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:24 GMT
 - request:
     method: delete
@@ -1597,8 +1597,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:24 GMT
 - request:
     method: delete
@@ -1638,8 +1638,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:24 GMT
 - request:
     method: delete
@@ -1679,8 +1679,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:25 GMT
 - request:
     method: delete
@@ -1720,8 +1720,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:25 GMT
 - request:
     method: delete
@@ -1761,8 +1761,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:25 GMT
 - request:
     method: delete
@@ -1802,8 +1802,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:25 GMT
 - request:
     method: delete
@@ -1843,8 +1843,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:25 GMT
 - request:
     method: delete
@@ -1884,8 +1884,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:25 GMT
 - request:
     method: delete
@@ -1925,8 +1925,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:25 GMT
 - request:
     method: delete
@@ -1966,8 +1966,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:25 GMT
 - request:
     method: delete
@@ -2007,8 +2007,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:25 GMT
 - request:
     method: delete
@@ -2048,8 +2048,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:25 GMT
 - request:
     method: delete
@@ -2089,8 +2089,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:25 GMT
 - request:
     method: delete
@@ -2130,8 +2130,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:26 GMT
 - request:
     method: delete
@@ -2171,8 +2171,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:26 GMT
 - request:
     method: delete
@@ -2212,8 +2212,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:26 GMT
 - request:
     method: delete
@@ -2253,8 +2253,8 @@ http_interactions:
       - thin 1.6.1 codename Death Proof
     body:
       encoding: UTF-8
-      string: '{"status":"Enqueued","process_token":null,"retry_after":20}'
-    http_version: 
+      string: '{"status":"Enqueued","process_token":null,"retry_after":0}'
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:26 GMT
 - request:
     method: delete
@@ -2291,6 +2291,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 05 Nov 2014 16:48:26 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/RedboothRuby_Session/_refresh_access_token_/.yml
+++ b/spec/cassettes/RedboothRuby_Session/_refresh_access_token_/.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://redbooth.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: client_id=_your_consumer_key_&client_secret=_your_consumer_secret_&grant_type=refresh_token&refresh_token=_your_user_refresh_token_
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Feb 2015 19:04:21 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - nginx
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Cache:
+      - invalidate, pass
+      X-Request-Id:
+      - ae886c7b4f2c7fed8d6777b92282938d
+      X-Runtime:
+      - '0.098434'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Content-Length:
+      - '185'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"_your_new_user_token_","token_type":"bearer","expires_in":7200,"refresh_token":"_your_new_user_refresh_token_","scope":"all"}'
+    http_version:
+  recorded_at: Tue, 17 Feb 2015 19:04:22 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/RedboothRuby_Session/_refresh_access_token_/call_on_token_refresh_with_the_old_and_new_token.yml
+++ b/spec/cassettes/RedboothRuby_Session/_refresh_access_token_/call_on_token_refresh_with_the_old_and_new_token.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://redbooth.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: client_id=_your_consumer_key_&client_secret=_your_consumer_secret_&grant_type=refresh_token&refresh_token=_your_user_refresh_token_
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Feb 2015 19:04:21 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - nginx
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Cache:
+      - invalidate, pass
+      X-Request-Id:
+      - ae886c7b4f2c7fed8d6777b92282938d
+      X-Runtime:
+      - '0.098434'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Content-Length:
+      - '185'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"_your_new_user_token_","token_type":"bearer","expires_in":7200,"refresh_token":"_your_new_user_refresh_token_","scope":"all"}'
+    http_version:
+  recorded_at: Tue, 17 Feb 2015 19:04:22 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/RedboothRuby_Session/_refresh_access_token_/refreshes_the_access_token.yml
+++ b/spec/cassettes/RedboothRuby_Session/_refresh_access_token_/refreshes_the_access_token.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://redbooth.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: client_id=_your_consumer_key_&client_secret=_your_consumer_secret_&grant_type=refresh_token&refresh_token=_your_user_refresh_token_
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Feb 2015 19:04:21 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - nginx
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Rack-Cache:
+      - invalidate, pass
+      X-Request-Id:
+      - ae886c7b4f2c7fed8d6777b92282938d
+      X-Runtime:
+      - '0.098434'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Content-Length:
+      - '185'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"_your_new_user_token_","token_type":"bearer","expires_in":7200,"refresh_token":"_your_new_user_refresh_token_","scope":"all"}'
+    http_version:
+  recorded_at: Tue, 17 Feb 2015 19:04:22 GMT
+recorded_with: VCR 2.9.3

--- a/spec/redbooth-ruby/base_spec.rb
+++ b/spec/redbooth-ruby/base_spec.rb
@@ -1,9 +1,9 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Base do
-  describe "#parse_timestamps" do
-    context "given #created_time is present" do
-      it "creates a Time object" do
+  describe '#parse_timestamps' do
+    context 'given #created_time is present' do
+      it 'creates a Time object' do
         base = RedboothRuby::Base.new(created_time: 1358300444)
         expect(base.created_time.class).to eql(Time)
       end

--- a/spec/redbooth-ruby/client_operations/metadata_spec.rb
+++ b/spec/redbooth-ruby/client_operations/metadata_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::ClientOperations::Metadata, vcr: 'metadata' do
   include_context 'authentication'
@@ -10,10 +10,10 @@ describe RedboothRuby::ClientOperations::Metadata, vcr: 'metadata' do
   end
   let(:endpoint) { 'metadata/search' }
 
-  describe ".metadata" do
+  describe '.metadata' do
     subject { client.metadata(search_params) }
 
-    it "makes a new GET request using the correct API endpoint to receive notes collection" do
+    it 'makes a new GET request using the correct API endpoint to receive notes collection' do
       expect(RedboothRuby).to receive(:request).with(:get, nil, endpoint, search_params, { session: session }).and_call_original
       subject
     end

--- a/spec/redbooth-ruby/client_operations/perform_spec.rb
+++ b/spec/redbooth-ruby/client_operations/perform_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+describe RedboothRuby::ClientOperations::Perform do
+  let(:access_token) do
+    {
+      token: '_your_user_token_',
+      secret: '_your_secret_token_',
+      refresh_token: '_your_user_reset_token_'
+    }
+  end
+  let(:session) { RedboothRuby::Session.new(access_token) }
+  let(:performer) { RedboothRuby::ClientOperations::Perform.new(:user, :show, session) }
+
+  describe '#initialize' do
+    subject { performer }
+
+    it { expect(performer.resource_name).to eql :user }
+    it { expect(performer.action).to eql :show }
+    it { expect(performer.session).to eql session }
+  end
+
+  describe '#perform!' do
+    it 'is private' do
+      expect{ performer.perform! }.to raise_error
+    end
+    it 'raises RedboothRuby::AuthenticationError if session is invalid' do
+      allow(performer).to receive(:session).and_return(nil)
+      expect{ performer.perform! }.to raise_error(RedboothRuby::AuthenticationError)
+    end
+    it 'calls to the given resource' do
+      allow(RedboothRuby::User).to receive(:show).and_return(RedboothRuby::User.new)
+      expect(RedboothRuby::User).to receive(:show).with({ session: session })
+
+      performer.perform!
+    end
+
+    context 'oauth token expired' do
+      before do
+        allow(RedboothRuby::User).to receive(:show).and_raise(RedboothRuby::OauthTokenExpired)
+      end
+      it 'tries to refresh access_token' do
+        allow(session).to receive(:refresh_access_token!).and_return({})
+        expect(session).to receive(:refresh_access_token!)
+        expect{ performer.perform! }.to raise_error(RedboothRuby::OauthTokenExpired)
+      end
+      it 'raise error if `refresh_access_token` fails' do
+        allow(session).to receive(:refresh_access_token!).and_return(nil)
+        expect{ performer.perform! }.to raise_error(RedboothRuby::OauthTokenExpired)
+      end
+      it 'raise error if `auto_refresh_token` is disabled' do
+        session.auto_refresh_token = false
+        expect{ performer.perform! }.to raise_error(RedboothRuby::OauthTokenExpired)
+      end
+    end
+  end
+
+  describe '#perform_processing!' do
+    let(:processing) do
+      RedboothRuby::Processing.new(OpenStruct.new(data: { 'retry_after' => '0' }))
+    end
+    it 'delays the processing' do
+      allow(performer).to receive(:processing_error).and_return(processing)
+      allow(performer).to receive(:perform!).and_return(nil)
+      expect(performer).to receive(:perform!).once
+      performer.perform_processing!
+    end
+    it 'retries the the processing' do
+      allow(performer).to receive(:processing_error).and_return(processing)
+      expect(performer).to receive(:retry_in).with(0)
+      performer.perform_processing!
+    end
+    it 'use 10 seconds as default delay' do
+      expect(performer).to receive(:retry_in).with(10)
+      performer.perform_processing!
+    end
+  end
+
+  describe '#perform_oauth_token_expired!' do
+    let(:oauth_token_expired_error) { RedboothRuby::OauthTokenExpired.new }
+    before do
+      allow(performer).to receive(:oauth_token_expired_error).and_return(oauth_token_expired_error)
+    end
+
+    context 'when it\'s the first attempt and refresh access token present' do
+      before do
+        allow(performer.session).to receive(:refresh_access_token!).and_return({})
+        allow(performer).to receive(:tries).and_return(1)
+      end
+      it 'refreshes the session access token' do
+        allow(performer).to receive(:perform!)
+        allow(performer).to receive(:refresh_session_access_token!).and_return(true)
+        expect(performer).to receive(:refresh_session_access_token!).once
+        performer.perform_oauth_token_expired!
+      end
+      it 'retries the processing' do
+        expect(performer).to receive(:perform!).once
+        performer.perform_oauth_token_expired!
+      end
+    end
+
+    context 'raising the exception' do
+      it 'when the number of tries is not 1' do
+        allow(performer).to receive(:tries).and_return(2)
+        expect{ performer.perform_oauth_token_expired! }.to raise_error(oauth_token_expired_error)
+      end
+
+      it 'when refresh access token is nil' do
+        allow(performer.session).to receive(:refresh_access_token!).and_return(nil)
+        expect{ performer.perform_oauth_token_expired! }.to raise_error(oauth_token_expired_error)
+      end
+    end
+  end
+
+  describe '#options_with_session' do
+    it 'is private' do
+      expect{ performer.options_with_session({}) }.to raise_error
+    end
+    it 'adds the session to the given options' do
+      expect(performer.send(:options_with_session, {})).to include(:session)
+      expect(performer.send(:options_with_session, {})[:session]).to eql(session)
+    end
+  end
+
+  describe '#resource' do
+    it 'is private' do
+      expect{ performer.resource('user') }.to raise_error
+    end
+    it 'gives the correct api resource class' do
+      expect(performer.send(:resource, 'user')).to eql(RedboothRuby::User)
+    end
+    it 'gives nil if there is no resource for the given name' do
+      expect(performer.send(:resource, 'icecream')).to be_nil
+    end
+  end
+end

--- a/spec/redbooth-ruby/client_operations/search_spec.rb
+++ b/spec/redbooth-ruby/client_operations/search_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::ClientOperations::Search, vcr: 'search' do
   include_context 'authentication'
@@ -10,10 +10,10 @@ describe RedboothRuby::ClientOperations::Search, vcr: 'search' do
   end
   let(:endpoint) { 'search' }
 
-  describe ".index" do
+  describe '.index' do
     subject { client.search(query: 'task') }
 
-    it "makes a new GET request using the correct API endpoint to receive notes collection" do
+    it 'makes a new GET request using the correct API endpoint to receive notes collection' do
       expect(RedboothRuby).to receive(:request).with(:get, nil, endpoint, { query: 'task' }, { session: session }).and_call_original
       subject
     end

--- a/spec/redbooth-ruby/client_spec.rb
+++ b/spec/redbooth-ruby/client_spec.rb
@@ -1,8 +1,6 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Client do
-  let(:consumer_key) { '_your_consumen_key_' }
-  let(:consumer_secret) { '_your_consumen_secret_' }
   let(:access_token) do
     {
       token: '_your_user_token_',
@@ -27,43 +25,4 @@ describe RedboothRuby::Client do
       expect{client}.to raise_error{ RedboothRuby::AuthenticationError }
     end
   end
-
-  describe '#perform!' do
-    it 'is private' do
-      expect{client.perform!(:user, :show)}.to raise_error
-    end
-    it 'raises RedboothRuby::AuthenticationError if session is invalid' do
-      allow(client).to receive(:session).and_return(nil)
-      expect{client.perform!(:user, :show)}.to raise_error{ RedboothRuby::AuthenticationError }
-    end
-    it 'calls to the given resource' do
-      allow(RedboothRuby::User).to receive(:show).and_return(RedboothRuby::User.new)
-      expect(RedboothRuby::User).to receive(:show).with({ session: session })
-
-      client.send(:perform!, :user, :show)
-    end
-  end
-
-  describe '#options_with_session' do
-    it 'is private' do
-      expect{client.options_with_session({})}.to raise_error
-    end
-    it 'adds the session to the given options' do
-      expect(client.send(:options_with_session,{})).to include(:session)
-      expect(client.send(:options_with_session,{})[:session]).to eql(session)
-    end
-  end
-
-  describe '#resource' do
-    it 'is private' do
-      expect{client.resource('user')}.to raise_error
-    end
-    it 'gives the correct api resource class' do
-      expect(client.send(:resource, 'user')).to eql(RedboothRuby::User)
-    end
-    it 'gives nil if there is no resource for the given name' do
-      expect(client.send(:resource, 'icecream')).to be_nil
-    end
-  end
-
 end

--- a/spec/redbooth-ruby/comment_spec.rb
+++ b/spec/redbooth-ruby/comment_spec.rb
@@ -1,5 +1,4 @@
-# Encoding: utf-8
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Comment, vcr: 'comments' do
   include_context 'authentication'
@@ -16,7 +15,7 @@ describe RedboothRuby::Comment, vcr: 'comments' do
     client.comment(:show, id: 1)
   end
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { comment }
 
     it { expect(subject.id).to eql 1 }
@@ -27,11 +26,11 @@ describe RedboothRuby::Comment, vcr: 'comments' do
     it { expect(subject.is_private).to eql false }
   end
 
-  describe ".show" do
+  describe '.show' do
     subject { comment }
 
-    it "makes a new GET request using the correct API endpoint to receive a specific comment" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{endpoint}/1", {}, { session: session }).and_call_original
+    it 'makes a new GET request using the correct API endpoint to receive a specific comment' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{ endpoint }/1", {}, { session: session }).and_call_original
       subject
     end
 
@@ -40,11 +39,11 @@ describe RedboothRuby::Comment, vcr: 'comments' do
     it { expect(subject.project_id).to eql 2 }
   end
 
-  describe ".update" do
+  describe '.update' do
     subject { client.comment(:update, id: 24, body: 'new test body') }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific comment" do
-      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{endpoint}/24", { body: 'new test body' }, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific comment' do
+      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{ endpoint }/24", { body: 'new test body' }, { session: session }).and_call_original
       subject
     end
 
@@ -52,10 +51,10 @@ describe RedboothRuby::Comment, vcr: 'comments' do
     it { expect(subject.id).to eql 24 }
   end
 
-  describe ".create" do
+  describe '.create' do
     subject { new_record }
 
-    it "makes a new POST request using the correct API endpoint to create a specific comment" do
+    it 'makes a new POST request using the correct API endpoint to create a specific comment' do
       expect(RedboothRuby).to receive(:request).with(:post, nil, endpoint, create_params, { session: session }).and_call_original
       subject
     end
@@ -65,20 +64,20 @@ describe RedboothRuby::Comment, vcr: 'comments' do
     it { expect(subject.user_id).to eql 1 }
   end
 
-  describe ".delete" do
+  describe '.delete' do
     subject { client.comment(:delete, id: new_record.id) }
 
-    it "makes a new DELETE request using the correct API endpoint to delete a specific comment" do
-      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{endpoint}/#{new_record.id}", {}, { session: session }).and_call_original
+    it 'makes a new DELETE request using the correct API endpoint to delete a specific comment' do
+      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{ endpoint }/#{ new_record.id }", {}, { session: session }).and_call_original
       subject
     end
   end
 
-  describe ".index" do
+  describe '.index' do
     subject { client.comment(:index, target_type: 'Task', target_id: 1) }
 
-    it "makes a new GET request using the correct API endpoint to receive comments collection" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, endpoint, {target_type: 'Task', target_id: 1}, { session: session }).and_call_original
+    it 'makes a new GET request using the correct API endpoint to receive comments collection' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, endpoint, { target_type: 'Task', target_id: 1 }, { session: session }).and_call_original
       subject
     end
 

--- a/spec/redbooth-ruby/conversation_spec.rb
+++ b/spec/redbooth-ruby/conversation_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Conversation, vcr: 'conversations' do
   include_context 'authentication'
@@ -13,7 +13,7 @@ describe RedboothRuby::Conversation, vcr: 'conversations' do
     client.conversation(:show, id: 1)
   end
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { conversation }
 
     it { expect(subject.id).to eql 1 }
@@ -23,11 +23,11 @@ describe RedboothRuby::Conversation, vcr: 'conversations' do
     it { expect(subject.is_private).to eql false }
   end
 
-  describe ".show" do
+  describe '.show' do
     subject { conversation }
 
-    it "makes a new GET request using the correct API endpoint to receive a specific conversation" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{endpoint}/1", {}, { session: session }).and_call_original
+    it 'makes a new GET request using the correct API endpoint to receive a specific conversation' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{ endpoint }/1", {}, { session: session }).and_call_original
       subject
     end
 
@@ -36,11 +36,11 @@ describe RedboothRuby::Conversation, vcr: 'conversations' do
     it { expect(subject.project_id).to eql 2 }
   end
 
-  describe ".update" do
+  describe '.update' do
     subject { client.conversation(:update, id: 2, name: 'new test name') }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific conversation" do
-      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{endpoint}/2", { name: 'new test name' }, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific conversation' do
+      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{ endpoint }/2", { name: 'new test name' }, { session: session }).and_call_original
       subject
     end
 
@@ -48,10 +48,10 @@ describe RedboothRuby::Conversation, vcr: 'conversations' do
     it { expect(subject.id).to eql 2 }
   end
 
-  describe ".create" do
+  describe '.create' do
     subject { new_record }
 
-    it "makes a new POST request using the correct API endpoint to create a specific conversation" do
+    it 'makes a new POST request using the correct API endpoint to create a specific conversation' do
       expect(RedboothRuby).to receive(:request).with(:post, nil, endpoint, create_params, { session: session }).and_call_original
       subject
     end
@@ -61,19 +61,19 @@ describe RedboothRuby::Conversation, vcr: 'conversations' do
     it { expect(subject.user_id).to eql 1 }
   end
 
-  describe ".delete" do
+  describe '.delete' do
     subject { client.conversation(:delete, id: new_record.id) }
 
-    it "makes a new DELETE request using the correct API endpoint to delete a specific conversation" do
-      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{endpoint}/#{new_record.id}", {}, { session: session }).and_call_original
+    it 'makes a new DELETE request using the correct API endpoint to delete a specific conversation' do
+      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{ endpoint }/#{ new_record.id }", {}, { session: session }).and_call_original
       subject
     end
   end
 
-  describe ".index" do
+  describe '.index' do
     subject { client.conversation(:index) }
 
-    it "makes a new GET request using the correct API endpoint to receive conversations collection" do
+    it 'makes a new GET request using the correct API endpoint to receive conversations collection' do
       expect(RedboothRuby).to receive(:request).with(:get, nil, endpoint, {}, { session: session }).and_call_original
       subject
     end

--- a/spec/redbooth-ruby/file_spec.rb
+++ b/spec/redbooth-ruby/file_spec.rb
@@ -1,5 +1,4 @@
-# Encoding: utf-8
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::File, vcr: 'files' do
   include_context 'authentication'
@@ -7,7 +6,7 @@ describe RedboothRuby::File, vcr: 'files' do
   let(:create_params) do
     { project_id: 2,
       backend: 'redbooth',
-      asset: File.open("#{File.dirname(__FILE__)}/../fixtures/hola.txt") }
+      asset: File.open("#{ File.dirname(__FILE__) }/../fixtures/hola.txt") }
   end
   let(:new_record) { client.file(:create, create_params) }
   let(:endpoint) { 'files' }
@@ -15,34 +14,34 @@ describe RedboothRuby::File, vcr: 'files' do
     client.file(:show, id: 1)
   end
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { file }
 
     it { expect(subject.id).to eql 1 }
-    it { expect(subject.name).to eql "Reports" }
+    it { expect(subject.name).to eql 'Reports' }
     it { expect(subject.project_id).to eql 2 }
     it { expect(subject.parent_id).to eql nil }
     it { expect(subject.pinned).to eql false }
   end
 
-  describe ".show" do
+  describe '.show' do
     subject { file }
 
-    it "makes a new GET request using the correct API endpoint to receive a specific file" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{endpoint}/1", {}, { session: session }).and_call_original
+    it 'makes a new GET request using the correct API endpoint to receive a specific file' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{ endpoint }/1", {}, { session: session }).and_call_original
       subject
     end
 
     it { expect(subject.id).to eql 1 }
-    it { expect(subject.name).to eql "Reports" }
+    it { expect(subject.name).to eql 'Reports' }
     it { expect(subject.project_id).to eql 2 }
   end
 
-  describe ".update" do
+  describe '.update' do
     subject { client.file(:update, id: 2, name: 'new_name.txt') }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific file" do
-      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{endpoint}/2", { name: 'new_name.txt' }, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific file' do
+      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{ endpoint }/2", { name: 'new_name.txt' }, { session: session }).and_call_original
       subject
     end
 
@@ -50,13 +49,13 @@ describe RedboothRuby::File, vcr: 'files' do
     it { expect(subject.id).to eql 2 }
   end
 
-  describe ".create" do
+  describe '.create' do
     subject { new_record }
     let(:asset_params) {
-      { asset_attrs: { name: "hola.txt", local_path: "#{File.dirname(__FILE__)}/../fixtures/hola.txt"} }
+      { asset_attrs: { name: 'hola.txt', local_path: "#{ File.dirname(__FILE__) }/../fixtures/hola.txt"} }
     }
 
-    it "makes a new POST request using the correct API endpoint to create a specific file" do
+    it 'makes a new POST request using the correct API endpoint to create a specific file' do
       expect(RedboothRuby).to receive(:request).with(:post, nil, endpoint, create_params.merge(asset_params) , { session: session }).and_call_original
       subject
     end
@@ -67,20 +66,20 @@ describe RedboothRuby::File, vcr: 'files' do
     it { expect(subject.user_id).to eql 1 }
   end
 
-  describe ".delete" do
+  describe '.delete' do
     subject { client.file(:delete, id: new_record.id) }
 
-    it "makes a new DELETE request using the correct API endpoint to delete a specific comment" do
-      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{endpoint}/#{new_record.id}", {}, { session: session }).and_call_original
+    it 'makes a new DELETE request using the correct API endpoint to delete a specific comment' do
+      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{ endpoint }/#{ new_record.id }", {}, { session: session }).and_call_original
       subject
     end
   end
 
-  describe ".index" do
+  describe '.index' do
     subject { client.file(:index, project_id: 1) }
 
-    it "makes a new GET request using the correct API endpoint to receive comments collection" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, endpoint, {project_id: 1}, { session: session }).and_call_original
+    it 'makes a new GET request using the correct API endpoint to receive comments collection' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, endpoint, { project_id: 1 }, { session: session }).and_call_original
       subject
     end
 
@@ -91,7 +90,7 @@ describe RedboothRuby::File, vcr: 'files' do
     subject { new_record.download }
 
     it 'downloads a file' do
-      open("#{File.dirname(__FILE__)}/../../temp/spec/files/test_download.txt", 'w') { |f| f.puts subject }
+      open("#{ File.dirname(__FILE__) }/../../temp/spec/files/test_download.txt", 'w') { |f| f.puts subject }
     end
   end
 end

--- a/spec/redbooth-ruby/me_spec.rb
+++ b/spec/redbooth-ruby/me_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Me, vcr: 'me' do
   include_context 'authentication'

--- a/spec/redbooth-ruby/membership_spec.rb
+++ b/spec/redbooth-ruby/membership_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Membership, vcr: 'membership' do
   include_context 'authentication'
@@ -14,7 +14,7 @@ describe RedboothRuby::Membership, vcr: 'membership' do
     client.membership(:show, id: 1)
   end
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { membership }
 
     it { expect(subject.id).to eql 1 }
@@ -22,11 +22,11 @@ describe RedboothRuby::Membership, vcr: 'membership' do
     it { expect(subject.role).to eql 'admin' }
   end
 
-  describe ".show" do
+  describe '.show' do
     subject { membership }
 
-    it "makes a new GET request using the correct API endpoint to receive a specific membership" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{endpoint_name}/1", {}, { session: session }).and_call_original
+    it 'makes a new GET request using the correct API endpoint to receive a specific membership' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{ endpoint_name }/1", {}, { session: session }).and_call_original
       subject
     end
 
@@ -35,11 +35,11 @@ describe RedboothRuby::Membership, vcr: 'membership' do
     it { expect(subject.role).to eql 'admin' }
   end
 
-  describe ".update" do
+  describe '.update' do
     subject { client.membership(:update, id: 6, role: 'admin') }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific membership" do
-      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{endpoint_name}/6", { role: 'admin' }, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific membership' do
+      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{ endpoint_name }/6", { role: 'admin' }, { session: session }).and_call_original
       subject
     end
 
@@ -47,12 +47,12 @@ describe RedboothRuby::Membership, vcr: 'membership' do
     it { expect(subject.id).to eql 6 }
   end
 
-  describe ".create" do
+  describe '.create' do
     subject { new_record }
     let(:response) { double(:response, data: {} )}
 
-    it "makes a new POST request using the correct API endpoint to create a specific membership" do
-      expect(RedboothRuby).to receive(:request).with(:post, nil, "#{endpoint_name}", create_params, { session: session }).and_return(response)
+    it 'makes a new POST request using the correct API endpoint to create a specific membership' do
+      expect(RedboothRuby).to receive(:request).with(:post, nil, endpoint_name, create_params, { session: session }).and_return(response)
       subject
     end
 
@@ -63,20 +63,20 @@ describe RedboothRuby::Membership, vcr: 'membership' do
     end
   end
 
-  describe ".delete" do
+  describe '.delete' do
     subject { client.membership(:delete, id: new_record.id) }
 
-    it "makes a new DELETE request using the correct API endpoint to delete a specific membership" do
-      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{endpoint_name}/#{new_record.id}", {}, { session: session }).and_call_original
+    it 'makes a new DELETE request using the correct API endpoint to delete a specific membership' do
+      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{ endpoint_name }/#{ new_record.id }", {}, { session: session }).and_call_original
       subject
     end
   end
 
-  describe ".index" do
+  describe '.index' do
     subject { client.membership(:index) }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific membership" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{endpoint_name}", {}, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific membership' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, endpoint_name, {}, { session: session }).and_call_original
       subject
     end
 

--- a/spec/redbooth-ruby/note_spec.rb
+++ b/spec/redbooth-ruby/note_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Note, vcr: 'notes' do
   include_context 'authentication'
@@ -14,7 +14,7 @@ describe RedboothRuby::Note, vcr: 'notes' do
     client.note(:show, id: 1)
   end
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { note }
 
     it { expect(subject.id).to eql 1 }
@@ -24,11 +24,11 @@ describe RedboothRuby::Note, vcr: 'notes' do
     it { expect(subject.is_private).to eql false }
   end
 
-  describe ".show" do
+  describe '.show' do
     subject { note }
 
-    it "makes a new GET request using the correct API endpoint to receive a specific note" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{endpoint}/1", {}, { session: session }).and_call_original
+    it 'makes a new GET request using the correct API endpoint to receive a specific note' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{ endpoint }/1", {}, { session: session }).and_call_original
       subject
     end
 
@@ -37,11 +37,11 @@ describe RedboothRuby::Note, vcr: 'notes' do
     it { expect(subject.project_id).to eql 2 }
   end
 
-  describe ".update" do
+  describe '.update' do
     subject { client.note(:update, id: 2, name: 'new test name') }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific note" do
-      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{endpoint}/2", { name: 'new test name' }, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific note' do
+      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{ endpoint }/2", { name: 'new test name' }, { session: session }).and_call_original
       subject
     end
 
@@ -49,10 +49,10 @@ describe RedboothRuby::Note, vcr: 'notes' do
     it { expect(subject.id).to eql 2 }
   end
 
-  describe ".create" do
+  describe '.create' do
     subject { new_record }
 
-    it "makes a new POST request using the correct API endpoint to create a specific note" do
+    it 'makes a new POST request using the correct API endpoint to create a specific note' do
       expect(RedboothRuby).to receive(:request).with(:post, nil, endpoint, create_params, { session: session }).and_call_original
       subject
     end
@@ -62,19 +62,19 @@ describe RedboothRuby::Note, vcr: 'notes' do
     it { expect(subject.user_id).to eql 1 }
   end
 
-  describe ".delete" do
+  describe '.delete' do
     subject { client.note(:delete, id: new_record.id) }
 
-    it "makes a new DELETE request using the correct API endpoint to delete a specific note" do
-      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{endpoint}/#{new_record.id}", {}, { session: session }).and_call_original
+    it 'makes a new DELETE request using the correct API endpoint to delete a specific note' do
+      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{ endpoint }/#{ new_record.id }", {}, { session: session }).and_call_original
       subject
     end
   end
 
-  describe ".index" do
+  describe '.index' do
     subject { client.note(:index) }
 
-    it "makes a new GET request using the correct API endpoint to receive notes collection" do
+    it 'makes a new GET request using the correct API endpoint to receive notes collection' do
       expect(RedboothRuby).to receive(:request).with(:get, nil, endpoint, {}, { session: session }).and_call_original
       subject
     end

--- a/spec/redbooth-ruby/organization_spec.rb
+++ b/spec/redbooth-ruby/organization_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Organization, vcr: 'organization' do
   include_context 'authentication'
@@ -11,7 +11,7 @@ describe RedboothRuby::Organization, vcr: 'organization' do
     client.organization(:show, id: 1)
   end
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { organization }
 
     it { expect(subject.id).to eql 1 }
@@ -20,11 +20,11 @@ describe RedboothRuby::Organization, vcr: 'organization' do
     it { expect(subject.domain).to eql nil }
   end
 
-  describe ".show" do
+  describe '.show' do
     subject { organization }
 
-    it "makes a new GET request using the correct API endpoint to receive a specific organization" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "organizations/1", {}, { session: session }).and_call_original
+    it 'makes a new GET request using the correct API endpoint to receive a specific organization' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, 'organizations/1', {}, { session: session }).and_call_original
       subject
     end
 
@@ -34,11 +34,11 @@ describe RedboothRuby::Organization, vcr: 'organization' do
     it { expect(subject.domain).to eql nil }
   end
 
-  describe ".update" do
+  describe '.update' do
     subject { client.organization(:update, id: 2, name: 'new test name') }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific organization" do
-      expect(RedboothRuby).to receive(:request).with(:put, nil, "organizations/2", { name: 'new test name' }, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific organization' do
+      expect(RedboothRuby).to receive(:request).with(:put, nil, 'organizations/2', { name: 'new test name' }, { session: session }).and_call_original
       subject
     end
 
@@ -46,10 +46,10 @@ describe RedboothRuby::Organization, vcr: 'organization' do
     it { expect(subject.id).to eql 2 }
   end
 
-  describe ".create" do
+  describe '.create' do
     subject { new_organization }
 
-    it "makes a new POST request using the correct API endpoint to create a specific organization" do
+    it 'makes a new POST request using the correct API endpoint to create a specific organization' do
       expect(RedboothRuby).to receive(:request).with(:post, nil, "organizations", create_organization_params, { session: session }).and_call_original
       subject
     end
@@ -57,21 +57,21 @@ describe RedboothRuby::Organization, vcr: 'organization' do
     it { expect(subject.name).to eql 'new Organization' }
   end
 
-  describe ".delete" do
+  describe '.delete' do
     subject { client.organization(:delete, id: new_organization.id) }
     before { allow_any_instance_of(RedboothRuby::Client).to receive(:sleep) }
 
-    it "makes a new DELETE request using the correct API endpoint to delete a specific organization" do
+    it 'makes a new DELETE request using the correct API endpoint to delete a specific organization' do
       expect(RedboothRuby).to receive(:request).with(:delete, nil, "organizations/#{new_organization.id}", {}, { session: session }).twice.and_call_original
       subject
     end
   end
 
-  describe ".index" do
+  describe '.index' do
     subject { client.organization(:index) }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific organization" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "organizations", {}, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific organization' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, 'organizations', {}, { session: session }).and_call_original
       subject
     end
 

--- a/spec/redbooth-ruby/person_spec.rb
+++ b/spec/redbooth-ruby/person_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Person, vcr: 'person' do
   include_context 'authentication'
@@ -14,7 +14,7 @@ describe RedboothRuby::Person, vcr: 'person' do
     client.person(:show, id: 1)
   end
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { person }
 
     it { expect(subject.id).to eql 1 }
@@ -22,11 +22,11 @@ describe RedboothRuby::Person, vcr: 'person' do
     it { expect(subject.role).to eql 'admin' }
   end
 
-  describe ".show" do
+  describe '.show' do
     subject { person }
 
-    it "makes a new GET request using the correct API endpoint to receive a specific person" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{endpoint_name}/1", {}, { session: session }).and_call_original
+    it 'makes a new GET request using the correct API endpoint to receive a specific person' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{ endpoint_name }/1", {}, { session: session }).and_call_original
       subject
     end
 
@@ -35,11 +35,11 @@ describe RedboothRuby::Person, vcr: 'person' do
     it { expect(subject.role).to eql 'admin' }
   end
 
-  describe ".update" do
+  describe '.update' do
     subject { client.person(:update, id: 6, role: 'admin') }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific person" do
-      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{endpoint_name}/6", { role: 'admin' }, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific person' do
+      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{ endpoint_name }/6", { role: 'admin' }, { session: session }).and_call_original
       subject
     end
 
@@ -47,12 +47,12 @@ describe RedboothRuby::Person, vcr: 'person' do
     it { expect(subject.id).to eql 6 }
   end
 
-  describe ".create" do
+  describe '.create' do
     subject { new_person }
     let(:response) { double(:response, data: {} )}
 
-    it "makes a new POST request using the correct API endpoint to create a specific person" do
-      expect(RedboothRuby).to receive(:request).with(:post, nil, "#{endpoint_name}", create_params, { session: session }).and_return(response)
+    it 'makes a new POST request using the correct API endpoint to create a specific person' do
+      expect(RedboothRuby).to receive(:request).with(:post, nil, endpoint_name, create_params, { session: session }).and_return(response)
       subject
     end
 
@@ -63,20 +63,20 @@ describe RedboothRuby::Person, vcr: 'person' do
     end
   end
 
-  describe ".delete" do
+  describe '.delete' do
     subject { client.person(:delete, id: new_person.id) }
 
-    it "makes a new DELETE request using the correct API endpoint to delete a specific person" do
-      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{endpoint_name}/#{new_person.id}", {}, { session: session }).and_call_original
+    it 'makes a new DELETE request using the correct API endpoint to delete a specific person' do
+      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{ endpoint_name }/#{ new_person.id }", {}, { session: session }).and_call_original
       subject
     end
   end
 
-  describe ".index" do
+  describe '.index' do
     subject { client.person(:index) }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific person" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{endpoint_name}", {}, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific person' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, endpoint_name, {}, { session: session }).and_call_original
       subject
     end
 

--- a/spec/redbooth-ruby/project_spec.rb
+++ b/spec/redbooth-ruby/project_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Project, vcr: 'project' do
   include_context 'authentication'
@@ -13,7 +13,7 @@ describe RedboothRuby::Project, vcr: 'project' do
     client.project(:show, id: 1)
   end
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { project }
 
     it { expect(subject.id).to eql 1 }
@@ -21,11 +21,11 @@ describe RedboothRuby::Project, vcr: 'project' do
     it { expect(subject.permalink).to eql 'general' }
   end
 
-  describe ".show" do
+  describe '.show' do
     subject { project }
 
-    it "makes a new GET request using the correct API endpoint to receive a specific project" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{endpoint_name}/1", {}, { session: session }).and_call_original
+    it 'makes a new GET request using the correct API endpoint to receive a specific project' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{ endpoint_name }/1", {}, { session: session }).and_call_original
       subject
     end
 
@@ -34,11 +34,11 @@ describe RedboothRuby::Project, vcr: 'project' do
     it { expect(subject.permalink).to eql 'general' }
   end
 
-  describe ".update" do
+  describe '.update' do
     subject { client.project(:update, id: 2, name: 'new test name') }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific project" do
-      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{endpoint_name}/2", { name: 'new test name' }, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific project' do
+      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{ endpoint_name }/2", { name: 'new test name' }, { session: session }).and_call_original
       subject
     end
 
@@ -46,32 +46,32 @@ describe RedboothRuby::Project, vcr: 'project' do
     it { expect(subject.id).to eql 2 }
   end
 
-  describe ".create" do
+  describe '.create' do
     subject { new_project }
 
-    it "makes a new POST request using the correct API endpoint to create a specific project" do
-      expect(RedboothRuby).to receive(:request).with(:post, nil, "#{endpoint_name}", create_params, { session: session }).and_call_original
+    it 'makes a new POST request using the correct API endpoint to create a specific project' do
+      expect(RedboothRuby).to receive(:request).with(:post, nil, endpoint_name, create_params, { session: session }).and_call_original
       subject
     end
 
     it { expect(subject.name).to eql 'new Project' }
   end
 
-  describe ".delete" do
+  describe '.delete' do
     subject { client.project(:delete, id: new_project.id) }
     before { allow_any_instance_of(RedboothRuby::Client).to receive(:sleep) }
 
-    it "makes a new DELETE request using the correct API endpoint to delete a specific project" do
-      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{endpoint_name}/#{new_project.id}", {}, { session: session }).at_least(:twice).and_call_original
+    it 'makes a new DELETE request using the correct API endpoint to delete a specific project' do
+      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{ endpoint_name }/#{ new_project.id }", {}, { session: session }).at_least(:twice).and_call_original
       subject
     end
   end
 
-  describe ".index" do
+  describe '.index' do
     subject { client.project(:index) }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific project" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{endpoint_name}", {}, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific project' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, endpoint_name, {}, { session: session }).and_call_original
       subject
     end
 

--- a/spec/redbooth-ruby/request/base_spec.rb
+++ b/spec/redbooth-ruby/request/base_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Request::Base do
   let(:consumer_key) { '_your_consumen_key_' }
@@ -18,12 +18,12 @@ describe RedboothRuby::Request::Base do
     end
   end
 
-  describe "#perform" do
+  describe '#perform' do
     it 'raises AuthenticationError if request is not valid' do
       allow(request_base).to receive(:valid?).and_return(false)
       expect{request_base.perform}.to raise_error{ RedboothRuby::AuthenticationError }
     end
-    it "performs an https request" do
+    it 'performs an https request' do
       allow_any_instance_of(RedboothRuby::Request::Base).to receive(:valid?).and_return(true)
 
       expect(connection).to receive(:set_request_data)
@@ -34,7 +34,7 @@ describe RedboothRuby::Request::Base do
     end
   end
 
-  describe "#valid?" do
+  describe '#valid?' do
     it 'is not valid if no info object given' do
       expect(RedboothRuby::Request::Base.new(nil)).to_not be_valid
     end

--- a/spec/redbooth-ruby/request/collection_spec.rb
+++ b/spec/redbooth-ruby/request/collection_spec.rb
@@ -1,10 +1,10 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Request::Collection, vcr: 'collection' do
   include_context 'authentication'
   let(:collection) { client.task(:index, per_page: 2) }
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { collection }
 
     it { should be_a RedboothRuby::Request::Collection }

--- a/spec/redbooth-ruby/request/connection_spec.rb
+++ b/spec/redbooth-ruby/request/connection_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Request::Connection do
   let(:consumer_key) { '_your_consumen_key_' }
@@ -21,7 +21,7 @@ describe RedboothRuby::Request::Connection do
   let(:client) { RedboothRuby::Client.new(session) }
   let(:session) { RedboothRuby::Session.new(access_token) }
   let(:redbooth_protocol) { RedboothRuby.configuration[:use_ssl] ? 'https' : 'http' }
-  let(:redbooth_url) { "#{redbooth_protocol}://#{RedboothRuby.configuration[:api_base]}/#{RedboothRuby.configuration[:api_base_path]}/#{RedboothRuby.configuration[:api_version]}" }
+  let(:redbooth_url) { "#{ redbooth_protocol }://#{ RedboothRuby.configuration[:api_base] }/#{ RedboothRuby.configuration[:api_base_path] }/#{ RedboothRuby.configuration[:api_version] }" }
 
   before :each do
     RedboothRuby.config do |configuration|
@@ -64,9 +64,9 @@ describe RedboothRuby::Request::Connection do
       expect(connection.request_data).to eq(
         [
           :post,
-          "#{redbooth_url}/some/path",
-          { body: { email: "abc_abc.com",
-                    event_types: ["user.created", "user.failed", "team.created", "documents.available"] }
+          "#{ redbooth_url }/some/path",
+          { body: { email: 'abc_abc.com',
+                    event_types: ['user.created', 'user.failed', 'team.created', 'documents.available'] }
           }
         ]
       )
@@ -75,8 +75,8 @@ describe RedboothRuby::Request::Connection do
 
   def params
     {
-      email: "abc_abc.com",
-      event_types: ["user.created","user.failed", "team.created", "documents.available"]
+      email: 'abc_abc.com',
+      event_types: ['user.created', 'user.failed', 'team.created', 'documents.available']
     }
   end
 end

--- a/spec/redbooth-ruby/request/info_spec.rb
+++ b/spec/redbooth-ruby/request/info_spec.rb
@@ -1,27 +1,27 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Request::Info do
-  describe "#url" do
-    it "constructs the url" do
-      info = RedboothRuby::Request::Info.new(:get, nil, "random", {id: 1} )
+  describe '#url' do
+    it 'constructs the url' do
+      info = RedboothRuby::Request::Info.new(:get, nil, 'random', { id: 1 })
 
       expect(info.url).to match /random/
     end
   end
 
-  describe "#path_with_params" do
-    it "does nothing when no params" do
-      info = RedboothRuby::Request::Info.new(:get, nil, "random", nil)
-      path = "/path/to/someplace"
+  describe '#path_with_params' do
+    it 'does nothing when no params' do
+      info = RedboothRuby::Request::Info.new(:get, nil, 'random', nil)
+      path = '/path/to/someplace'
 
       expect(info.path_with_params(path, {})).to eq path
     end
 
-    it "constructs the path with params" do
-      info = RedboothRuby::Request::Info.new(:get, nil, "random", nil)
-      path = "/path/to/someplace"
+    it 'constructs the path with params' do
+      info = RedboothRuby::Request::Info.new(:get, nil, 'random', nil)
+      path = '/path/to/someplace'
 
-      expect(info.path_with_params(path, {random: "stuff"})).to eq "#{path}?random=stuff"
+      expect(info.path_with_params(path, { random: 'stuff' })).to eq "#{ path }?random=stuff"
     end
   end
 end

--- a/spec/redbooth-ruby/request/response_spec.rb
+++ b/spec/redbooth-ruby/request/response_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Request::Response do
   let(:headers) { {} }
@@ -8,11 +8,11 @@ describe RedboothRuby::Request::Response do
                                                    status: status,
                                                    headers: headers) }
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { response }
 
     it { should be_a RedboothRuby::Request::Response }
-    it { expect(subject.data).to eq("response" => "ok") }
+    it { expect(subject.data).to eq('response' => 'ok') }
     it { expect(subject.body).to eq(body) }
     it { expect(subject.headers).to eq(headers) }
     it { expect(subject.status).to eq(status) }

--- a/spec/redbooth-ruby/request/validator_spec.rb
+++ b/spec/redbooth-ruby/request/validator_spec.rb
@@ -1,16 +1,16 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Request::Validator do
-  let(:info) { RedboothRuby::Request::Info.new(:get, nil, "random", OpenStruct.new(id: 1)) }
+  let(:info) { RedboothRuby::Request::Info.new(:get, nil, 'random', OpenStruct.new(id: 1)) }
   let(:validator) { RedboothRuby::Request::Validator.new info }
   let(:headers) { {} }
   let(:response) { OpenStruct.new(body: '{"response":"ok"}', status: 200, headers: headers) }
 
-  describe "#validated_response_for" do
+  describe '#validated_response_for' do
     subject { validator.validated_response_for(response) }
 
     it { should be_a RedboothRuby::Request::Response }
-    it { expect(subject.data).to eq("response" => "ok") }
+    it { expect(subject.data).to eq('response' => 'ok') }
 
     context 'where 401 status code returned' do
       let(:response) { OpenStruct.new(body: '{"error":{"message":"Unauthorized"}}', status: 401, headers: headers) }
@@ -20,13 +20,13 @@ describe RedboothRuby::Request::Validator do
       context 'where token was expired' do
         before { headers['WWW-Authenticate'] = %{Bearer realm="Doorkeeper", error="invalid_token", error_description="The access token was expired"} }
 
-        it { expect{subject}.to raise_error(RedboothRuby::OauhtTokenExpired) }
+        it { expect{subject}.to raise_error(RedboothRuby::OauthTokenExpired) }
       end
 
       context 'where token was revoked' do
         before { headers['WWW-Authenticate'] = %{Bearer realm="Doorkeeper", error="invalid_token", error_description="The access token was revoked"} }
 
-        it { expect{subject}.to raise_error(RedboothRuby::OauhtTokenRevoked) }
+        it { expect{subject}.to raise_error(RedboothRuby::OauthTokenRevoked) }
       end
     end
 

--- a/spec/redbooth-ruby/session_spec.rb
+++ b/spec/redbooth-ruby/session_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+describe RedboothRuby::Session, vcr: 'session' do
+  let(:token) { '_your_user_token_' }
+  let(:refresh_token) { '_your_user_refresh_token_' }
+  let(:expires_in) { 7200 }
+  let(:auto_refresh_token) { true }
+  let(:consumer_key) { '_your_consumer_key_' }
+  let(:consumer_secret) { '_your_consumer_secret_' }
+  let(:session) do
+    RedboothRuby::Session.new(token: token, refresh_token: refresh_token,
+      expires_in: expires_in, auto_refresh_token: auto_refresh_token,
+      consumer_key: consumer_key, consumer_secret: consumer_secret)
+  end
+
+  describe '#initialize' do
+    subject { session }
+
+    it { expect(session.token).to eql token }
+    it { expect(session.refresh_token).to eql refresh_token }
+    it { expect(session.expires_in).to eql expires_in }
+    it { expect(session.auto_refresh_token).to eql auto_refresh_token }
+    it { expect(session.consumer_key).to eql consumer_key }
+    it { expect(session.consumer_secret).to eql consumer_secret }
+  end
+
+  describe '#valid?' do
+    subject { session.valid? }
+    it { should eql true }
+
+    context 'when token is empty' do
+      before { session.token = nil }
+      it { should eql false }
+    end
+  end
+
+  describe '#client' do
+    subject(:client) { session.client }
+    it { should be_a OAuth2::Client }
+    it { expect(client.id).to eql consumer_key }
+    it { expect(client.secret).to eql consumer_secret }
+  end
+
+  describe '#get_access_token_url' do
+    subject { session.get_access_token_url }
+    it { should eql 'https://redbooth.com/oauth2/token' }
+
+    context 'when oauth_verifier is present' do
+      before { session.oauth_verifier = '_your_user_oauth_verifier_token_' }
+      it { should eql 'https://redbooth.com/oauth2/token?oauth_verifier=_your_user_oauth_verifier_token_' }
+    end
+
+    context 'when oauth_token is present' do
+      before { session.oauth_token = '_your_user_oauth_token_' }
+      it { should eql 'https://redbooth.com/oauth2/token?oauth_token=_your_user_oauth_token_' }
+    end
+
+    context 'when oauth_verifier and oauth_token are present' do
+      before do
+        session.oauth_verifier = '_your_user_oauth_verifier_token_'
+        session.oauth_token = '_your_user_oauth_token_'
+      end
+      it { should eql 'https://redbooth.com/oauth2/token?oauth_verifier=_your_user_oauth_verifier_token_&oauth_token=_your_user_oauth_token_' }
+    end
+  end
+
+  describe '#access_token' do
+    subject(:access_token) { session.access_token }
+    it { should be_a OAuth2::AccessToken }
+    it { expect(access_token.client).to eql session.client }
+    it { expect(access_token.token).to eql session.token }
+    it { expect(access_token.refresh_token).to eql session.refresh_token }
+    it { expect(access_token.expires_in).to eql session.expires_in }
+  end
+
+  describe '#refresh_access_token!' do
+    subject(:access_token) { session.access_token }
+
+    it 'refreshes the access token' do
+      session.refresh_access_token!
+      expect(access_token.token).to eql('_your_new_user_token_')
+      expect(access_token.refresh_token).to eql('_your_new_user_refresh_token_')
+    end
+
+    it 'call `on_token_refresh` with the old and new token' do
+      on_token_refresh = Proc.new { |old_token, new_token| }
+      session.on_token_refresh = on_token_refresh
+
+      allow(on_token_refresh).to receive(:call) do |old_token, new_token|
+        expect(old_token.token).to eql('_your_user_token_')
+        expect(old_token.refresh_token).to eql('_your_user_refresh_token_')
+
+        expect(new_token.token).to eql('_your_new_user_token_')
+        expect(new_token.refresh_token).to eql('_your_new_user_refresh_token_')
+      end
+
+      session.refresh_access_token!
+    end
+  end
+end

--- a/spec/redbooth-ruby/subtaks_spec.rb
+++ b/spec/redbooth-ruby/subtaks_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Subtask, vcr: 'subtasks' do
   include_context 'authentication'
@@ -14,7 +14,7 @@ describe RedboothRuby::Subtask, vcr: 'subtasks' do
     client.subtask(:show, id: 1)
   end
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { subtask }
 
     it { expect(subject.id).to eql 1 }
@@ -23,11 +23,11 @@ describe RedboothRuby::Subtask, vcr: 'subtasks' do
     it { expect(subject.resolved).to eql true }
   end
 
-  describe ".show" do
+  describe '.show' do
     subject { subtask }
 
-    it "makes a new GET request using the correct API endpoint to receive a specific subtask" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{endpoint}/1", {}, { session: session }).and_call_original
+    it 'makes a new GET request using the correct API endpoint to receive a specific subtask' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, "#{ endpoint }/1", {}, { session: session }).and_call_original
       subject
     end
 
@@ -36,11 +36,11 @@ describe RedboothRuby::Subtask, vcr: 'subtasks' do
     it { expect(subject.task_id).to eql 1 }
   end
 
-  describe ".update" do
+  describe '.update' do
     subject { client.subtask(:update, id: 2, name: 'new test name') }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific subtask" do
-      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{endpoint}/2", { name: 'new test name' }, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific subtask' do
+      expect(RedboothRuby).to receive(:request).with(:put, nil, "#{ endpoint }/2", { name: 'new test name' }, { session: session }).and_call_original
       subject
     end
 
@@ -48,10 +48,10 @@ describe RedboothRuby::Subtask, vcr: 'subtasks' do
     it { expect(subject.id).to eql 2 }
   end
 
-  describe ".create" do
+  describe '.create' do
     subject { new_record }
 
-    it "makes a new POST request using the correct API endpoint to create a specific subtask" do
+    it 'makes a new POST request using the correct API endpoint to create a specific subtask' do
       expect(RedboothRuby).to receive(:request).with(:post, nil, endpoint, create_params, { session: session }).and_call_original
       subject
     end
@@ -61,19 +61,19 @@ describe RedboothRuby::Subtask, vcr: 'subtasks' do
     it { expect(subject.resolved).to eql false }
   end
 
-  describe ".delete" do
+  describe '.delete' do
     subject { client.subtask(:delete, id: new_record.id) }
 
-    it "makes a new DELETE request using the correct API endpoint to delete a specific subtask" do
-      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{endpoint}/#{new_record.id}", {}, { session: session }).and_call_original
+    it 'makes a new DELETE request using the correct API endpoint to delete a specific subtask' do
+      expect(RedboothRuby).to receive(:request).with(:delete, nil, "#{ endpoint }/#{ new_record.id }", {}, { session: session }).and_call_original
       subject
     end
   end
 
-  describe ".index" do
+  describe '.index' do
     subject { client.subtask(:index, task_id: 2) }
 
-    it "makes a new GET request using the correct API endpoint to receive subtasks collection" do
+    it 'makes a new GET request using the correct API endpoint to receive subtasks collection' do
       expect(RedboothRuby).to receive(:request).with(:get, nil, endpoint, { task_id: 2 }, { session: session }).and_call_original
       subject
     end

--- a/spec/redbooth-ruby/task_spec.rb
+++ b/spec/redbooth-ruby/task_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::Task, vcr: 'tasks' do
   include_context 'authentication'
@@ -13,7 +13,7 @@ describe RedboothRuby::Task, vcr: 'tasks' do
     RedboothRuby::Task.show(session: session, id: 1)
   end
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { task }
 
     it { expect(subject.id).to eql 1 }
@@ -24,9 +24,9 @@ describe RedboothRuby::Task, vcr: 'tasks' do
     it { expect(subject.due_on).to eql '2014-11-04' }
   end
 
-  describe ".show" do
-    it "makes a new GET request using the correct API endpoint to receive a specific task" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "tasks/1", {}, { session: session }).and_call_original
+  describe '.show' do
+    it 'makes a new GET request using the correct API endpoint to receive a specific task' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, 'tasks/1', {}, { session: session }).and_call_original
       task
     end
     it 'returns a task with the correct name' do
@@ -43,11 +43,11 @@ describe RedboothRuby::Task, vcr: 'tasks' do
     end
   end
 
-  describe ".update" do
+  describe '.update' do
     subject { RedboothRuby::Task.update(session: session, id: 2, name: 'new test name') }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific task" do
-      expect(RedboothRuby).to receive(:request).with(:put, nil, "tasks/2", { name: 'new test name' }, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific task' do
+      expect(RedboothRuby).to receive(:request).with(:put, nil, 'tasks/2', { name: 'new test name' }, { session: session }).and_call_original
       subject
     end
 
@@ -55,11 +55,11 @@ describe RedboothRuby::Task, vcr: 'tasks' do
     it { expect(subject.id).to eql 2 }
   end
 
-  describe ".create" do
+  describe '.create' do
     subject { new_task }
 
-    it "makes a new POST request using the correct API endpoint to create a specific task" do
-      expect(RedboothRuby).to receive(:request).with(:post, nil, "tasks", create_task_params, { session: session }).and_call_original
+    it 'makes a new POST request using the correct API endpoint to create a specific task' do
+      expect(RedboothRuby).to receive(:request).with(:post, nil, 'tasks', create_task_params, { session: session }).and_call_original
       subject
     end
 
@@ -68,20 +68,20 @@ describe RedboothRuby::Task, vcr: 'tasks' do
     it { expect(subject.task_list_id).to eql 3 }
   end
 
-  describe ".delete" do
+  describe '.delete' do
     subject { RedboothRuby::Task.delete(session: session, id: new_task.id) }
 
-    it "makes a new DELETE request using the correct API endpoint to delete a specific task" do
+    it 'makes a new DELETE request using the correct API endpoint to delete a specific task' do
       expect(RedboothRuby).to receive(:request).with(:delete, nil, "tasks/#{new_task.id}", {}, { session: session }).and_call_original
       subject
     end
   end
 
-  describe ".index" do
+  describe '.index' do
     subject { RedboothRuby::Task.index(session: session) }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific task" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "tasks", {}, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific task' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, 'tasks', {}, { session: session }).and_call_original
       subject
     end
 
@@ -91,8 +91,8 @@ describe RedboothRuby::Task, vcr: 'tasks' do
   describe '.medatada' do
     subject { task.metadata }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific task" do
-      expect(RedboothRuby).to receive(:request).with(:get, nil, "metadata", { target_type: 'Task', target_id: task.id }, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific task' do
+      expect(RedboothRuby).to receive(:request).with(:get, nil, 'metadata', { target_type: 'Task', target_id: task.id }, { session: session }).and_call_original
       subject
     end
 
@@ -103,8 +103,8 @@ describe RedboothRuby::Task, vcr: 'tasks' do
   describe '.medatada=' do
     subject { task.metadata = { 'new' => 'metadata' } }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific task" do
-      expect(RedboothRuby).to receive(:request).with(:post, nil, "metadata", { target_type: 'Task', target_id: task.id, metadata: { 'new' => 'metadata' } }, { session: session }).and_call_original
+    it 'makes a new PUT request using the correct API endpoint to receive a specific task' do
+      expect(RedboothRuby).to receive(:request).with(:post, nil, 'metadata', { target_type: 'Task', target_id: task.id, metadata: { 'new' => 'metadata' } }, { session: session }).and_call_original
       subject
     end
 
@@ -117,7 +117,7 @@ describe RedboothRuby::Task, vcr: 'tasks' do
     before { task.metadata = { 'new' => 'metadata', 'other' => 'value' } }
     subject { task.metadata_merge( 'other' => 'updated_value') }
 
-    it "makes a new PUT request using the correct API endpoint to receive a specific task" do
+    it 'makes a new PUT request using the correct API endpoint to receive a specific task' do
       expect(RedboothRuby).to receive(:request).with(:put, nil, "metadata", { target_type: 'Task', target_id: task.id, metadata: { 'other' => 'updated_value' } }, { session: session }).and_call_original
       subject
     end

--- a/spec/redbooth-ruby/user_spec.rb
+++ b/spec/redbooth-ruby/user_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby::User, vcr: 'users' do
   include_context 'authentication'
@@ -7,7 +7,7 @@ describe RedboothRuby::User, vcr: 'users' do
     RedboothRuby::User.show(session: session, id: 1)
   end
 
-  describe "#initialize" do
+  describe '#initialize' do
     subject { user }
 
     it { expect(subject.email).to eql('example_frank@redbooth.com') }
@@ -16,7 +16,7 @@ describe RedboothRuby::User, vcr: 'users' do
     it { expect(subject.last_name).to eql('Kramer') }
   end
 
-  describe ".show" do
+  describe '.show' do
     subject { RedboothRuby::User.show(session: session, id: 1) }
 
     it 'makes a new GET request using the correct API endpoint to receive a specific user' do

--- a/spec/redbooth_spec.rb
+++ b/spec/redbooth_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe RedboothRuby do
   describe '.request' do
@@ -8,7 +8,7 @@ describe RedboothRuby do
       end
     end
 
-    context "with an invalid api key" do
+    context 'with an invalid api key' do
       let(:consumer_key) { '_your_consumen_key_' }
       let(:consumer_secret) { '_your_consumen_secret_' }
       let(:access_token) do
@@ -20,7 +20,7 @@ describe RedboothRuby do
       let(:client) { RedboothRuby::Client.new(session) }
       let(:session) { RedboothRuby::Session.new(access_token) }
       let(:redbooth_protocol) { RedboothRuby.configuration[:use_ssl] ? 'https' : 'http' }
-      let(:redbooth_url) { "#{redbooth_protocol}://#{RedboothRuby.configuration[:api_base]}/#{RedboothRuby.configuration[:api_base_path]}/#{RedboothRuby.configuration[:api_version]}" }
+      let(:redbooth_url) { "#{ redbooth_protocol }://#{ RedboothRuby.configuration[:api_base] }/#{ RedboothRuby.configuration[:api_base_path] }/#{ RedboothRuby.configuration[:api_version] }" }
 
       before(:each) do
         RedboothRuby.config do |configuration|
@@ -28,7 +28,7 @@ describe RedboothRuby do
           configuration[:consumer_secret] = consumer_secret
         end
         WebMock.stub_request(:any,
-                             /#{RedboothRuby.configuration[:api_base]}/
+                             /#{ RedboothRuby.configuration[:api_base] }/
                             ).to_return(body: '{}')
       end
 
@@ -38,7 +38,7 @@ describe RedboothRuby do
                      { session: session }
                     )
         expect(WebMock).to have_requested(:get,
-                                      "#{redbooth_url}/user?param_name=param_value"
+                                      "#{ redbooth_url }/user?param_name=param_value"
                                       )
       end
 
@@ -51,18 +51,18 @@ describe RedboothRuby do
                         )
         expect(WebMock).to have_requested(
           :get,
-          "#{redbooth_url}/user?client=client_id&order=created_at_desc"
+          "#{ redbooth_url }/user?client=client_id&order=created_at_desc"
         )
       end
 
-      it "doesn't add a question mark if no params" do
-        RedboothRuby.request(:post, nil, "user", {}, { session: session })
-        expect(WebMock).to have_requested(:post, "#{redbooth_url}/user")
+      it 'doesn\'t add a question mark if no params' do
+        RedboothRuby.request(:post, nil, 'user', {}, { session: session })
+        expect(WebMock).to have_requested(:post, "#{ redbooth_url }/user")
       end
 
-      it "uses the param id to construct the url" do
-        RedboothRuby.request(:post, nil, "user", {id: 'new_id'}, { session: session })
-        expect(WebMock).to have_requested(:post, "#{redbooth_url}/user/new_id")
+      it 'uses the param id to construct the url' do
+        RedboothRuby.request(:post, nil, 'user', { id: 'new_id' }, { session: session })
+        expect(WebMock).to have_requested(:post, "#{ redbooth_url }/user/new_id")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require "codeclimate-test-reporter"
+require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
@@ -24,5 +24,4 @@ end
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods
-  config.extend VCR::RSpec::Macros
 end


### PR DESCRIPTION
![refresh](http://captionsearch.com/pix/thumb/gkkllder-t.gif)

## What?

Support refresh_token in Ruby Library

## Why?

Because by default, our access token expires in 7200 seconds and users need a ease way to handle it

## How to test?

```ruby
require 'redbooth-ruby'

RedboothRuby.config do |configuration|
  configuration[:consumer_key] = '_your_consumer_key_'
  configuration[:consumer_secret] = '_your_consumer_secret_'
end

session = RedboothRuby::Session.new(
  token: '_your_user_token_',
  refresh_token: '_your_user_refresh_token_',
  auto_refresh_token: true,
  on_token_refresh: Proc.new do |old_access_token, new_access_token|
    auth = Authentication.where(access_token: old_access_token.token).first
    auth.access_token = new_access_token.token
    auth.refresh_token = new_access_token.refresh_token
    auth.save
  end
)

client = RedboothRuby::Client.new(session)
p client.me(:show)
```