### PR TITLE
By default, use net_http_persistent adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem 'webmock'
 gem 'pry'
 gem 'multipart-post', '>= 1.1.0'
 gem "codeclimate-test-reporter", group: :test, require: nil
+gem 'net-http-persistent'

--- a/lib/redbooth-ruby/session.rb
+++ b/lib/redbooth-ruby/session.rb
@@ -24,6 +24,7 @@ module RedboothRuby
       @consumer_secret = opts[:consumer_secret] || RedboothRuby.configuration[:consumer_secret]
       @oauth_verifier = opts[:oauth_verifier]
       @oauth_token = opts[:oauth_token]
+      @http_adapter = opts[:http_adapter] || :net_http_persistent
     end
 
     def valid?
@@ -32,7 +33,9 @@ module RedboothRuby
     end
 
     def client
-      @client ||= OAuth2::Client.new(consumer_key, consumer_secret, OAUTH_URLS)
+      @client ||= OAuth2::Client.new(consumer_key, consumer_secret, OAUTH_URLS) do |builder|
+        builder.adapter = @http_adapter
+      end
     end
 
     def get_access_token_url


### PR DESCRIPTION
![giphy-2](https://cloud.githubusercontent.com/assets/56472/6807591/9fada582-d24f-11e4-98f6-5fa066ee91a3.gif)

## What?

Start using the `net_http_persistent` Faraday adapter by default.

## Why?

To improve HTTPS loading times, taking advantage of persistence features such as keep-alive.