### PR TITLE
Use older OAuth2 for compatibility with Teambox-hosted

### DIFF
--- a/redbooth-ruby.gemspec
+++ b/redbooth-ruby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'json', '>= 1.8.1'
-  s.add_dependency 'oauth2', '>= 0.9.3'
+  s.add_dependency 'oauth2', '~> 0.8'
   s.add_dependency(%q<multipart-post>, ['>= 1.1.0'])
 
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
![](http://images4.fanpop.com/image/photos/18700000/Random-gifs-random-18723411-368-312.gif)
## What?
Use older OAuth2 for compatibility with Teambox-hosted.

## Why?
To be able to use redbooth-ruby with Teambox-hosted.