### PR TITLE
Only tasks and subtasks have row_order.

### DIFF
--- a/lib/redbooth-ruby/note.rb
+++ b/lib/redbooth-ruby/note.rb
@@ -18,7 +18,6 @@ module RedboothRuby
                   :token,
                   :updated_by_id,
                   :deleted,
-                  :row_order,
                   :created_at,
                   :updated_at
   end

--- a/lib/redbooth-ruby/task_list.rb
+++ b/lib/redbooth-ruby/task_list.rb
@@ -14,7 +14,6 @@ module RedboothRuby
                   :start_on,
                   :finish_on,
                   :position,
-                  :row_order,
                   :archived,
                   :archived_tasks_count,
                   :tasks_count,


### PR DESCRIPTION
# WAT

I mistakenly added row_order to notes and task lists while only tasks and task_lists have it.

# gif

![](http://i.giphy.com/BX17E98mJ45TG.gif)