### PR TITLE
Revert OAuth2::Client behavior.

### DIFF
--- a/lib/redbooth-ruby/session.rb
+++ b/lib/redbooth-ruby/session.rb
@@ -34,7 +34,9 @@ module RedboothRuby
     end
 
     def client
-      @client ||= OAuth2::Client.new(consumer_key, consumer_secret, @oauth_urls)
+      options = @oauth_urls
+      options[:raise_errors] = false
+      @client ||= OAuth2::Client.new(consumer_key, consumer_secret, options)
     end
 
     def get_access_token_url


### PR DESCRIPTION
In previous versions, OAuth2 would always return with a `response` and
its corresponding status code and body. New release of OAuth2 raises
exceptions for different codes and breaks our code.

This was not found by our specs because we're mocking the response from
OAuth2 and we don't test its expected behavior.

![lol](http://media.giphy.com/media/nfVG8ss1mIYpy/giphy.gif)