### PR TITLE
Remove codeclimate integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'codeclimate-test-reporter', require: nil

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/teambox/redbooth-ruby.svg?branch=master)](https://travis-ci.org/teambox/redbooth-ruby) [![Code Climate](https://codeclimate.com/repos/5461c4f6e30ba075bc0a0ab0/badges/11031f420440e8a9f525/gpa.svg)](https://codeclimate.com/repos/5461c4f6e30ba075bc0a0ab0/feed) [![Test Coverage](https://codeclimate.com/repos/5461c4f6e30ba075bc0a0ab0/badges/11031f420440e8a9f525/coverage.svg)](https://codeclimate.com/repos/5461c4f6e30ba075bc0a0ab0/feed) [![Inline docs](http://inch-ci.org/github/teambox/redbooth-ruby.svg?branch=master)](http://inch-ci.org/github/teambox/redbooth-ruby)
+[![Build Status](https://travis-ci.org/redbooth/redbooth-ruby.svg?branch=master)](https://travis-ci.org/redbooth/redbooth-ruby)
 
 Redbooth-Ruby
 ======

--- a/redbooth-ruby.gemspec
+++ b/redbooth-ruby.gemspec
@@ -24,9 +24,8 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'pry', '~> 0.10'
-  s.add_development_dependency 'vcr', '~> 3.0'
+  s.add_development_dependency 'vcr', '~> 2.9'
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'webmock', '~> 1.22'
   s.add_development_dependency 'rack-test', '~> 0.6'
-  s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,3 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'redbooth-ruby'
@@ -15,7 +12,6 @@ Dir[File.join(File.dirname(__FILE__), 'shared/**/*.rb')].each {|f| require f}
 
 # VCR cassette configuration
 VCR.configure do |config|
-  config.ignore_hosts 'codeclimate.com'
   config.cassette_library_dir     = 'spec/cassettes'
   config.hook_into                :webmock
   config.default_cassette_options = { record: :new_episodes }


### PR DESCRIPTION
RedboothRuby will no longer integrate with Code Climate. This change updates the specs so they don't report to Code Climate and removes README badges related to the integration.

For development, VCR is pinned to 2.9 for backwards compatibility.